### PR TITLE
Add benchmark Hamiltonian database

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,11 @@ flowchart TD
   E["FiniteDifferenceMatrices.jl"]
   F["FDM.jl"]
   G["VMC.jl"]
+  H["DB.jl"]
   Z["TwoBody.jl"]
+  A --> H
   A --> C & D & F & G
+  H --> C & D & F & G
   B --> C & D
   E --> F
   C & D & F & G --> Z

--- a/README.md
+++ b/README.md
@@ -16,20 +16,15 @@ config:
 ---
 flowchart TD
   A["Hamiltonian.jl"]
-  B["Basis.jl"]
   C["Rayleigh-Ritz.jl"]
-  D["GEM.jl"]
-  E["FiniteDifferenceMatrices.jl"]
   F["FDM.jl"]
   G["VMC.jl"]
   H["DB.jl"]
   Z["TwoBody.jl"]
   A --> H
-  A --> C & D & F & G
-  H --> C & D & F & G
-  B --> C & D
-  E --> F
-  C & D & F & G --> Z
+  A --> C & F & G
+  H --> C & F & G
+  C & F & G --> Z
 ```
 
 ## Developer's Guide

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ makedocs(;
     pages=[
         "Home" => "index.md",
         "Hamiltonian" => "Hamiltonian.md",
+        "Database" => "DB.md",
         "Rayleigh-Ritz Method" => "Rayleigh-Ritz.md",
         "Finite Difference Method" => "FDM.md",
         "API reference" => "API.md",

--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -1,0 +1,74 @@
+```@meta
+CurrentModule = TwoBody
+```
+
+# Database
+
+The internal database provides benchmark Hamiltonians and their reference
+energies for developing and testing solvers. Database functionality is not
+exported because it is intended for package development.
+
+```julia
+entry = TwoBody.db(:hydrogen)
+hamiltonian = entry.hamiltonian
+reference_energy = entry.energy
+```
+
+The returned Hamiltonian can be passed to a solver, and the calculated energy
+can then be compared with the reference value.
+
+```mermaid
+flowchart TD
+    B["input"]
+    C["TwoBody.db"]
+    D["solver"]
+    E["test"]
+    F["output"]
+
+    B -->|"key"| C
+    C -->|"Hamiltonian"| D
+    D -->|"calculated energy"| E
+    C -->|"reference energy"| E
+    E -->|"true / false"| F
+```
+
+## Available data
+
+The proof of concept contains three problems in atomic units:
+
+| Key | System | Reference energy |
+|:--|:--|--:|
+| `:hydrogen` | Hydrogen ground state | `-0.5` |
+| `:positronium` | Positronium ground state | `-0.25` |
+| `:harmonic_oscillator` | Three-dimensional harmonic oscillator ground state | `1.5` |
+
+Use `TwoBody.dbkeys()` to obtain the available keys programmatically. Both
+symbols and strings are accepted by `TwoBody.db`.
+
+## Adding data
+
+Use the internal `TwoBody.@put` macro to register a key, Hamiltonian, and real
+reference energy. Duplicate keys are rejected.
+
+```julia
+TwoBody.@put(
+    :example,
+    Hamiltonian(
+        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
+        CoulombPotential(coefficient = -1.0),
+    ),
+    -0.5,
+)
+```
+
+Registration and lookup both copy the Hamiltonian so that modifying a returned
+entry does not alter the stored benchmark.
+
+## API
+
+```@docs
+TwoBody.DatabaseEntry
+TwoBody.var"@put"
+TwoBody.db
+TwoBody.dbkeys
+```

--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -45,7 +45,7 @@ lookup to protect stored benchmarks.
 
 ## API
 
-```@docs
+```@docs; canonical=false
 TwoBody.DatabaseEntry
 TwoBody.put!
 TwoBody.db

--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -8,10 +8,12 @@ The internal database provides benchmark Hamiltonians and their reference
 energies for developing and testing solvers. Database functionality is not
 exported because it is intended for package development.
 
-```julia
-entry = TwoBody.db(:hydrogen)
-hamiltonian = entry.hamiltonian
-reference_energy = entry.energy
+```julia-repl
+julia> entry = TwoBody.db(:hydrogen)
+
+julia> entry.hamiltonian
+
+julia> entry.energy
 ```
 
 The returned Hamiltonian can be passed to a solver, and the calculated energy

--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -49,11 +49,11 @@ symbols and strings are accepted by `TwoBody.db`.
 
 ## Adding data
 
-Use the internal `TwoBody.@put` macro to register a key, Hamiltonian, and real
+Use the internal `TwoBody.put!` function to register a key, Hamiltonian, and real
 reference energy. Duplicate keys are rejected.
 
 ```julia
-TwoBody.@put(
+TwoBody.put!(
     :example,
     Hamiltonian(
         NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
@@ -70,7 +70,7 @@ entry does not alter the stored benchmark.
 
 ```@docs
 TwoBody.DatabaseEntry
-TwoBody.var"@put"
+TwoBody.put!
 TwoBody.db
 TwoBody.dbkeys
 ```

--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -8,6 +8,13 @@ The internal database provides benchmark Hamiltonians and their reference
 energies for developing and testing solvers. Database functionality is not
 exported because it is intended for package development.
 
+The returned Hamiltonian can be passed to a solver, and the calculated energy
+can then be compared with the reference value.
+
+## Usage
+
+Retrieve a benchmark using its key:
+
 ```julia-repl
 julia> entry = TwoBody.db(:hydrogen)
 
@@ -16,55 +23,27 @@ julia> entry.hamiltonian
 julia> entry.energy
 ```
 
-The returned Hamiltonian can be passed to a solver, and the calculated energy
-can then be compared with the reference value.
+Add a benchmark using `TwoBody.put!`:
 
-```mermaid
-flowchart TD
-    B["input"]
-    C["TwoBody.db"]
-    D["solver"]
-    E["test"]
-    F["output"]
+```julia-repl
+julia> hamiltonian = Hamiltonian(
+           NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
+           CoulombPotential(coefficient = -1.0),
+       )
 
-    B -->|"key"| C
-    C -->|"Hamiltonian"| D
-    D -->|"calculated energy"| E
-    C -->|"reference energy"| E
-    E -->|"true / false"| F
+julia> TwoBody.put!(:example, hamiltonian, -0.5)
 ```
 
-## Available data
+Duplicate keys are rejected. Registration and lookup both copy the Hamiltonian
+so that modifying a returned entry does not alter the stored benchmark.
 
-The proof of concept contains three problems in atomic units:
+## Data
 
 | Key | System | Reference energy |
 |:--|:--|--:|
 | `:hydrogen` | Hydrogen ground state | `-0.5` |
 | `:positronium` | Positronium ground state | `-0.25` |
 | `:harmonic_oscillator` | Three-dimensional harmonic oscillator ground state | `1.5` |
-
-Use `TwoBody.dbkeys()` to obtain the available keys programmatically. Both
-symbols and strings are accepted by `TwoBody.db`.
-
-## Adding data
-
-Use the internal `TwoBody.put!` function to register a key, Hamiltonian, and real
-reference energy. Duplicate keys are rejected.
-
-```julia
-TwoBody.put!(
-    :example,
-    Hamiltonian(
-        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
-        CoulombPotential(coefficient = -1.0),
-    ),
-    -0.5,
-)
-```
-
-Registration and lookup both copy the Hamiltonian so that modifying a returned
-entry does not alter the stored benchmark.
 
 ## API
 

--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -4,12 +4,10 @@ CurrentModule = TwoBody
 
 # Database
 
-The internal database provides benchmark Hamiltonians and their reference
-energies for developing and testing solvers. Database functionality is not
-exported because it is intended for package development.
-
-The returned Hamiltonian can be passed to a solver, and the calculated energy
-can then be compared with the reference value.
+The internal database provides benchmark Hamiltonians and reference energies
+for testing solvers. Each Hamiltonian can be passed to a solver and its result
+compared with the reference energy. The database is not exported because it is
+intended for package development.
 
 ## Usage
 
@@ -34,8 +32,8 @@ julia> hamiltonian = Hamiltonian(
 julia> TwoBody.put!(:example, hamiltonian, -0.5)
 ```
 
-Duplicate keys are rejected. Registration and lookup both copy the Hamiltonian
-so that modifying a returned entry does not alter the stored benchmark.
+Duplicate keys are rejected, and Hamiltonians are copied on registration and
+lookup to protect stored benchmarks.
 
 ## Data
 

--- a/docs/src/FDM.md
+++ b/docs/src/FDM.md
@@ -94,7 +94,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.E(HA,n=n))
+  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.energy(HA,n=n))
 end
 
 # wave function
@@ -119,7 +119,7 @@ for n in 1:4
   X = res.method.R
   Y = 4π * X .^2 .* res.ψ[:,n] .^ 2
   scatter!(axis, X, Y, label="TwoBody.jl", markersize=6)
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black)
   axislegend(axis, "n = $n", position=:rt, framevisible=false)
 end
 save("assets/FDM_HA.svg", fig) # hide
@@ -149,7 +149,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.E(SO,n=n-1))
+  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.energy(SO,n=n-1))
 end
 
 # wave function
@@ -174,7 +174,7 @@ for n in 1:4
   X = res.method.R
   Y = 4π * X .^2 .* res.ψ[:,n] .^ 2
   scatter!(axis, X, Y, label="TwoBody.jl", markersize=6)
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black)
   axislegend(axis, "n = $(n-1)", position=:rt, framevisible=false)
 end
 fig

--- a/docs/src/Rayleigh-Ritz.md
+++ b/docs/src/Rayleigh-Ritz.md
@@ -93,7 +93,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.E(HA,n=n))
+  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.energy(HA,n=n))
 end
 
 # wave function
@@ -116,7 +116,7 @@ for n in 1:4
     )
   )
   lines!(axis, 0..50, r -> 4π * r^2 * abs(TwoBody.ψ(res,r,n=n))^2, label="TwoBody.jl")
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black, linestyle=:dash)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black, linestyle=:dash)
   axislegend(axis, "n = $n", position=:rt, framevisible=false)
 end
 fig
@@ -147,7 +147,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.E(SO,n=n-1))
+  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.energy(SO,n=n-1))
 end
 
 # wave function
@@ -170,7 +170,7 @@ for n in 1:4
     )
   )
   lines!(axis, 0..50, r -> 4π * r^2 * abs(TwoBody.ψ(res,r,n=n))^2, label="TwoBody.jl")
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black, linestyle=:dash)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black, linestyle=:dash)
   axislegend(axis, "n = $(n-1)", position=:rt, framevisible=false)
 end
 fig

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -81,7 +81,7 @@ using CairoMakie
 fig = Figure(size=(420,300), fontsize=11, backgroundcolor=:transparent)
 axis = Axis(fig[1,1], xlabel=L"$r / a_0$", ylabel=L"$\psi(r) / a_0^{-3/2}$", ylabelsize=16.5, xlabelsize=16.5, limits=(0,4,0,1.1/sqrt(π)))
 lines!(axis, 0..5, r -> abs(TwoBody.ψ(res,r)), label="TwoBody.jl")
-lines!(axis, 0..5, r -> abs(Antique.ψ(HA,r,0,0)), linestyle=:dash, color=:black, label="Antique.jl")
+lines!(axis, 0..5, r -> abs(Antique.wavefunction(HA,r,0,0)), linestyle=:dash, color=:black, label="Antique.jl")
 axislegend(axis, position=:rt, framevisible=false)
 fig
 ```

--- a/src/DB.jl
+++ b/src/DB.jl
@@ -1,0 +1,112 @@
+"""
+    DatabaseEntry(hamiltonian, energy)
+
+A benchmark problem stored in the database. `hamiltonian` is ready to be
+passed to a solver and `energy` is its reference energy.
+"""
+struct DatabaseEntry{T<:Real}
+    hamiltonian::Hamiltonian
+    energy::T
+end
+
+# Keeping the registry private makes `db` the single lookup boundary and leaves
+# room for validation, lazy loading, and provenance.
+const _DATABASE = Dict{Symbol,DatabaseEntry}()
+
+function _register!(key::Symbol, hamiltonian::Hamiltonian, energy::T) where {T<:Real}
+    haskey(_DATABASE, key) &&
+        throw(ArgumentError("database key $(repr(key)) is already registered"))
+
+    entry = DatabaseEntry(deepcopy(hamiltonian), energy)
+    _DATABASE[key] = entry
+    return entry
+end
+
+_register!(key::AbstractString, hamiltonian::Hamiltonian, energy::Real) =
+    _register!(Symbol(key), hamiltonian, energy)
+
+"""
+    @put(key, hamiltonian, energy)
+
+Add a benchmark problem to the database. `key` may be a `Symbol` or string,
+`hamiltonian` must be a [`Hamiltonian`](@ref), and `energy` must be real.
+Registering the same key twice throws an `ArgumentError`.
+
+```julia
+@put(
+    :hydrogen,
+    Hamiltonian(
+        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
+        CoulombPotential(coefficient = -1.0),
+    ),
+    -0.5,
+)
+```
+"""
+macro put(key, hamiltonian, energy)
+    return :(_register!($(esc(key)), $(esc(hamiltonian)), $(esc(energy))))
+end
+
+# PoC data in atomic units.
+@put(
+    :hydrogen,
+    Hamiltonian(
+        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
+        CoulombPotential(coefficient = -1.0),
+    ),
+    -0.5,
+)
+
+@put(
+    :positronium,
+    Hamiltonian(
+        NonRelativisticKinetic(ℏ = 1.0, m = 0.5),
+        CoulombPotential(coefficient = -1.0),
+    ),
+    -0.25,
+)
+
+@put(
+    :harmonic_oscillator,
+    Hamiltonian(
+        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
+        PowerLawPotential(coefficient = 0.5, exponent = 2.0),
+    ),
+    1.5,
+)
+
+"""
+    db(key::Union{Symbol,AbstractString}) -> DatabaseEntry
+
+Return the benchmark Hamiltonian and reference energy associated with `key`.
+The returned Hamiltonian is independent of the stored value and can safely be
+modified by callers.
+
+# Examples
+
+```julia
+entry = db(:hydrogen)
+result = solve(entry.hamiltonian, method)
+isapprox(result.values[1], entry.energy)
+```
+"""
+function db(key::Symbol)
+    haskey(_DATABASE, key) || throw(
+        ArgumentError(
+            "unknown database key $(repr(key)); available keys: " *
+            join(repr.(dbkeys()), ", "),
+        ),
+    )
+
+    entry = _DATABASE[key]
+    return DatabaseEntry(deepcopy(entry.hamiltonian), entry.energy)
+end
+
+db(key::AbstractString) = db(Symbol(key))
+
+"""
+    dbkeys() -> Vector{Symbol}
+
+Return the available database keys in deterministic order.
+"""
+dbkeys() = sort!(collect(keys(_DATABASE)); by = string)

--- a/src/DB.jl
+++ b/src/DB.jl
@@ -9,11 +9,20 @@ struct DatabaseEntry{T<:Real}
     energy::T
 end
 
+import Base: put!
+
 # Keeping the registry private makes `db` the single lookup boundary and leaves
 # room for validation, lazy loading, and provenance.
 const _DATABASE = Dict{Symbol,DatabaseEntry}()
 
-function _register!(key::Symbol, hamiltonian::Hamiltonian, energy::T) where {T<:Real}
+"""
+    put!(key, hamiltonian, energy)
+
+Add a benchmark problem to the database. `key` may be a `Symbol` or string,
+`hamiltonian` must be a [`Hamiltonian`](@ref), and `energy` must be real.
+Registering the same key twice throws an `ArgumentError`.
+"""
+function put!(key::Symbol, hamiltonian::Hamiltonian, energy::T) where {T<:Real}
     haskey(_DATABASE, key) &&
         throw(ArgumentError("database key $(repr(key)) is already registered"))
 
@@ -22,33 +31,11 @@ function _register!(key::Symbol, hamiltonian::Hamiltonian, energy::T) where {T<:
     return entry
 end
 
-_register!(key::AbstractString, hamiltonian::Hamiltonian, energy::Real) =
-    _register!(Symbol(key), hamiltonian, energy)
-
-"""
-    @put(key, hamiltonian, energy)
-
-Add a benchmark problem to the database. `key` may be a `Symbol` or string,
-`hamiltonian` must be a [`Hamiltonian`](@ref), and `energy` must be real.
-Registering the same key twice throws an `ArgumentError`.
-
-```julia
-@put(
-    :hydrogen,
-    Hamiltonian(
-        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
-        CoulombPotential(coefficient = -1.0),
-    ),
-    -0.5,
-)
-```
-"""
-macro put(key, hamiltonian, energy)
-    return :(_register!($(esc(key)), $(esc(hamiltonian)), $(esc(energy))))
-end
+put!(key::AbstractString, hamiltonian::Hamiltonian, energy::Real) =
+    put!(Symbol(key), hamiltonian, energy)
 
 # PoC data in atomic units.
-@put(
+put!(
     :hydrogen,
     Hamiltonian(
         NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
@@ -57,7 +44,7 @@ end
     -0.5,
 )
 
-@put(
+put!(
     :positronium,
     Hamiltonian(
         NonRelativisticKinetic(ℏ = 1.0, m = 0.5),
@@ -66,7 +53,7 @@ end
     -0.25,
 )
 
-@put(
+put!(
     :harmonic_oscillator,
     Hamiltonian(
         NonRelativisticKinetic(ℏ = 1.0, m = 1.0),

--- a/src/TwoBody.jl
+++ b/src/TwoBody.jl
@@ -3,6 +3,9 @@ module TwoBody
 # Hamiltonian
 include("./Hamiltonian.jl")
 
+# Database
+include("./DB.jl")
+
 # Basis
 include("./Basis.jl")
 

--- a/test/DB.jl
+++ b/test/DB.jl
@@ -24,10 +24,10 @@
     )
 
     try
-        registered = TwoBody.@put(key, hamiltonian, -2.0)
+        registered = TwoBody.put!(key, hamiltonian, -2.0)
         @test registered isa TwoBody.DatabaseEntry{Float64}
         @test TwoBody.db(key).energy == -2.0
-        @test_throws ArgumentError TwoBody.@put(key, hamiltonian, -2.0)
+        @test_throws ArgumentError TwoBody.put!(key, hamiltonian, -2.0)
 
         # Registration also isolates the stored Hamiltonian from the caller.
         pop!(hamiltonian.terms)

--- a/test/DB.jl
+++ b/test/DB.jl
@@ -1,0 +1,38 @@
+@testset "Database" begin
+    hydrogen = TwoBody.db(:hydrogen)
+
+    @test hydrogen isa TwoBody.DatabaseEntry{Float64}
+    @test hydrogen.hamiltonian isa Hamiltonian
+    @test hydrogen.energy == -0.5
+    @test TwoBody.db("hydrogen").energy == hydrogen.energy
+    @test TwoBody.dbkeys() == [:harmonic_oscillator, :hydrogen, :positronium]
+    @test_throws ArgumentError TwoBody.db(:unknown)
+
+    positronium = TwoBody.db(:positronium)
+    @test positronium.energy == -0.25
+    @test positronium.hamiltonian[1].m == 0.5
+
+    # A caller may modify its Hamiltonian without corrupting the registry.
+    pop!(hydrogen.hamiltonian.terms)
+    @test length(hydrogen.hamiltonian) == 1
+    @test length(TwoBody.db(:hydrogen).hamiltonian) == 2
+
+    key = :temporary_test_problem
+    hamiltonian = Hamiltonian(
+        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
+        CoulombPotential(coefficient = -2.0),
+    )
+
+    try
+        registered = TwoBody.@put(key, hamiltonian, -2.0)
+        @test registered isa TwoBody.DatabaseEntry{Float64}
+        @test TwoBody.db(key).energy == -2.0
+        @test_throws ArgumentError TwoBody.@put(key, hamiltonian, -2.0)
+
+        # Registration also isolates the stored Hamiltonian from the caller.
+        pop!(hamiltonian.terms)
+        @test length(TwoBody.db(key).hamiltonian) == 2
+    finally
+        delete!(TwoBody._DATABASE, key)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using SpecialFunctions
 using ForwardDiff
 
 @testset verbose = true "TwoBody.jl" begin
+  include("DB.jl")
   include("Basis.jl")
   include("Rayleigh-Ritz.jl")
   include("FDM.jl")


### PR DESCRIPTION
## Summary

- add a database that maps keys to Hamiltonians and reference energies
- add the internal `put!` and `db()` functions
- register three benchmark problems: hydrogen, positronium, and harmonic-oscillator
- add lookup, key discovery, defensive copying, and focused tests
- document database usage, registration, available data, and internal APIs

This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.
