### PR TITLE
Update Antique.jl 0.15 API usage

### DIFF
--- a/docs/src/FDM.md
+++ b/docs/src/FDM.md
@@ -57,7 +57,7 @@ FDM = FiniteDifferenceMethod(
 nothing # hide
 ```
 
-Solve the eigenvalue problem. You should find reasonable approximations to [the exact eigenvalues](https://ohno.github.io/Antique.jl/stable/HydrogenAtom/#Antique.E-Tuple{HydrogenAtom}-HydrogenAtom):
+Solve the eigenvalue problem. You should find reasonable approximations to [the exact eigenvalues](https://ohno.github.io/Antique.jl/stable/HydrogenAtom/#Eigenvalues):
 ```math
 \begin{aligned}
   E_{n=1} &= -0.5,\\
@@ -85,7 +85,7 @@ res = solve(H, FDM, info=0, nₘₐₓ=4)
 
 # benchmark
 import Antique
-HA = Antique.HydrogenAtom(Z=1, Eₕ=1.0, a₀=1.0, mₑ=1.0, ℏ=1.0)
+HA = Antique.HydrogenAtom(Z=1, E_h=1.0, a_0=1.0, m_e=1.0, hbar=1.0)
 
 # energy
 using Printf
@@ -94,7 +94,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.E(HA,n=n))
+  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.energy(HA,n=n))
 end
 
 # wave function
@@ -119,7 +119,7 @@ for n in 1:4
   X = res.method.R
   Y = 4π * X .^2 .* res.ψ[:,n] .^ 2
   scatter!(axis, X, Y, label="TwoBody.jl", markersize=6)
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black)
   axislegend(axis, "n = $n", position=:rt, framevisible=false)
 end
 save("assets/FDM_HA.svg", fig) # hide
@@ -140,7 +140,7 @@ res = solve(H, FDM, info=0, nₘₐₓ=4)
 
 # benchmark
 import Antique
-SO = Antique.SphericalOscillator(k=1.0, μ=1.0, ℏ=1.0)
+SO = Antique.SphericalOscillator(k=1.0, mu=1.0, hbar=1.0)
 
 # energy
 using Printf
@@ -149,7 +149,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.E(SO,n=n-1))
+  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.energy(SO,n=n-1))
 end
 
 # wave function
@@ -174,7 +174,7 @@ for n in 1:4
   X = res.method.R
   Y = 4π * X .^2 .* res.ψ[:,n] .^ 2
   scatter!(axis, X, Y, label="TwoBody.jl", markersize=6)
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black)
   axislegend(axis, "n = $(n-1)", position=:rt, framevisible=false)
 end
 fig

--- a/docs/src/Rayleigh-Ritz.md
+++ b/docs/src/Rayleigh-Ritz.md
@@ -84,7 +84,7 @@ res = solve(H, BS)
 
 # benchmark
 import Antique
-HA = Antique.HydrogenAtom(Z=1, Eₕ=1.0, a₀=1.0, mₑ=1.0, ℏ=1.0)
+HA = Antique.HydrogenAtom(Z=1, E_h=1.0, a_0=1.0, m_e=1.0, hbar=1.0)
 
 # energy
 using Printf
@@ -93,7 +93,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.E(HA,n=n))
+  @printf("%2d  %+.9f  %+.9f\n", n, res.E[n], Antique.energy(HA,n=n))
 end
 
 # wave function
@@ -116,7 +116,7 @@ for n in 1:4
     )
   )
   lines!(axis, 0..50, r -> 4π * r^2 * abs(TwoBody.ψ(res,r,n=n))^2, label="TwoBody.jl")
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black, linestyle=:dash)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(HA,r,0,0,n=n))^2, label="Antique.jl", color=:black, linestyle=:dash)
   axislegend(axis, "n = $n", position=:rt, framevisible=false)
 end
 fig
@@ -138,7 +138,7 @@ res = solve(H, BS)
 
 # benchmark
 import Antique
-SO = Antique.SphericalOscillator(k=1.0, μ=1.0, ℏ=1.0)
+SO = Antique.SphericalOscillator(k=1.0, mu=1.0, hbar=1.0)
 
 # energy
 using Printf
@@ -147,7 +147,7 @@ println("------------------------------")
 println(" n     numerical    analytical")
 println("------------------------------")
 for n in 1:4
-  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.E(SO,n=n-1))
+  @printf("%2d  %+.9f  %+.9f\n", n-1, res.E[n], Antique.energy(SO,n=n-1))
 end
 
 # wave function
@@ -170,7 +170,7 @@ for n in 1:4
     )
   )
   lines!(axis, 0..50, r -> 4π * r^2 * abs(TwoBody.ψ(res,r,n=n))^2, label="TwoBody.jl")
-  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.ψ(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black, linestyle=:dash)
+  lines!(axis, 0..50, r -> 4π * r^2 * abs(Antique.wavefunction(SO,r,0,0,n=n-1))^2, label="Antique.jl", color=:black, linestyle=:dash)
   axislegend(axis, "n = $(n-1)", position=:rt, framevisible=false)
 end
 fig

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -74,14 +74,14 @@ res = solve(H, BS)
 
 # benchmark
 import Antique
-HA = Antique.HydrogenAtom(Z=1, Eₕ=1.0, a₀=1.0, mₑ=1.0, ℏ=1.0)
+HA = Antique.HydrogenAtom(Z=1, E_h=1.0, a_0=1.0, m_e=1.0, hbar=1.0)
 
 # plot
 using CairoMakie
 fig = Figure(size=(420,300), fontsize=11, backgroundcolor=:transparent)
 axis = Axis(fig[1,1], xlabel=L"$r / a_0$", ylabel=L"$\psi(r) / a_0^{-3/2}$", ylabelsize=16.5, xlabelsize=16.5, limits=(0,4,0,1.1/sqrt(π)))
 lines!(axis, 0..5, r -> abs(TwoBody.ψ(res,r)), label="TwoBody.jl")
-lines!(axis, 0..5, r -> abs(Antique.ψ(HA,r,0,0)), linestyle=:dash, color=:black, label="Antique.jl")
+lines!(axis, 0..5, r -> abs(Antique.wavefunction(HA,r,0,0)), linestyle=:dash, color=:black, label="Antique.jl")
 axislegend(axis, position=:rt, framevisible=false)
 fig
 ```

--- a/test/FDM.jl
+++ b/test/FDM.jl
@@ -38,13 +38,13 @@
   end
   
   # comparison with Antique.jl
-  HA = Antique.HydrogenAtom(Z=1, mₑ=1.0, a₀=1.0, Eₕ=1.0, ℏ=1.0)
+  HA = Antique.HydrogenAtom(Z=1, m_e=1.0, a_0=1.0, E_h=1.0, hbar=1.0)
 
   println("Energy")
   println("  i\tnumerical  \tanalytical")
   for i in 1:res.nₘₐₓ
     numerical  = res.E[i]
-    analytical = Antique.E(HA, n=i)
+    analytical = Antique.energy(HA, n=i)
     error = iszero(analytical) ? abs(numerical-analytical) : abs((numerical-analytical)/analytical)
     acceptance = error < 1e-2
     @printf("%3d\t%.9f\t%.9f\t%s\n", i, numerical, analytical, acceptance ? "✔" :  "✗")
@@ -58,7 +58,7 @@
     for i in keys(res.method.R[begin:min(10,length(res.method.R))])
         r = res.method.R[i]
         numerical  = abs(res.ψ[i,n])
-        analytical = abs(Antique.ψ(HA, r, 0, 0, n=n)) 
+        analytical = abs(Antique.wavefunction(HA, r, 0, 0, n=n))
         error = iszero(analytical) ? abs(numerical-analytical) : abs((numerical-analytical)/analytical)
         acceptance = error < 5e-2
         @printf("%3d\t%.1f\t%.9f\t%.9f\t%s\n", i, r, numerical, analytical, acceptance ? "✔" :  "✗")

--- a/test/Rayleigh-Ritz.jl
+++ b/test/Rayleigh-Ritz.jl
@@ -58,13 +58,13 @@
   @test acceptance
 
   # comparison with Antique.jl
-  HA = Antique.HydrogenAtom(Z=1, mₑ=1.0, a₀=1.0, Eₕ=1.0, ℏ=1.0)
+  HA = Antique.HydrogenAtom(Z=1, m_e=1.0, a_0=1.0, E_h=1.0, hbar=1.0)
 
   println("ψ(r)")
   println("  r\tnumerical  \tanalytical")
   for r in 0.2:0.1:2.0
     numerical  = abs(TwoBody.ψ(res, r, n=1))
-    analytical = abs(Antique.ψ(HA, r, 0, 0))
+    analytical = abs(Antique.wavefunction(HA, r, 0, 0))
     error = iszero(analytical) ? abs(numerical-analytical) : abs((numerical-analytical)/analytical)
     acceptance = error < 1e-2
     @printf("%.1f\t%.9f\t%.9f\t%s\n", r, numerical, analytical, acceptance ? "✔" :  "✗")


### PR DESCRIPTION
## Summary

- update `HydrogenAtom` and `SphericalOscillator` keyword arguments to the ASCII names used by Antique.jl 0.15
- replace `Antique.E` with `Antique.energy`
- replace `Antique.ψ` with `Antique.wavefunction`
- update the same API usage in executable documentation examples

## Root cause

Antique.jl 0.15 renamed its public functions and model fields, so the tests and documentation examples no longer compile against the latest release.

## Impact

The numerical expectations and tolerances are unchanged. Tests and documentation now use the supported Antique.jl API, allowing the documentation examples to generate their assets successfully.

## Validation

- `git diff --check` passed
- Julia 1.7 tests passed
- Julia 1.10 tests passed
- Documentation build passed
- compared all updated calls with Antique.jl 0.15.0 source and documentation

## Agents

This change was assisted by OpenAI Codex GPT-5.6-high:
- creating a Git branch
- updating Antique.jl API usage in tests and documentation
- validating the changes with GitHub Actions
- preparing the pull request

Close #18
