### PR TITLE
Release v0.0.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TwoBody"
 uuid = "a92d7657-722c-45a6-9d18-9da4c8a753b6"
 authors = ["Shuhei Ohno"]
-version = "0.0.9"
+version = "0.0.10"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"


### PR DESCRIPTION
## Summary

- bump the package version from `0.0.9` to `0.0.10`

## Why

`main` now contains the Rayleigh-Ritz result updates, the benchmark Hamiltonian database, and the Antique.jl 0.15 compatibility updates added since v0.0.9. This version bump prepares those changes for registration as v0.0.10.

## Impact

There are no source-code changes in this pull request. After merging, the resulting commit can be submitted to Julia Registrator.

## Validation

- `git diff --check` passed
- `Pkg.test()` passed on Julia 1.10: 271/271 tests
- the latest `main` GitHub Actions run passed on Julia 1.7, Julia 1.10, and Documentation

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.