### PR TITLE
Simplify Hamiltonian operator names

### DIFF
--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -25,8 +25,8 @@ Add a benchmark using `TwoBody.put!`:
 
 ```julia-repl
 julia> hamiltonian = Hamiltonian(
-           NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
-           CoulombPotential(coefficient = -1.0),
+           Kinetic(ℏ = 1.0, m = 1.0),
+           Coulomb(coefficient = -1.0),
        )
 
 julia> TwoBody.put!(:example, hamiltonian, -0.5)

--- a/docs/src/FDM.md
+++ b/docs/src/FDM.md
@@ -38,8 +38,8 @@ Define the [Hamiltoninan](@ref Hamiltonian). This is an example for the non-rela
 ```
 ```@example example
 H = Hamiltonian(
-  NonRelativisticKinetic(ℏ = 1 , m = 1),
-  CoulombPotential(coefficient = -1),
+  Kinetic(ℏ = 1, m = 1),
+  Coulomb(coefficient = -1),
 )
 nothing # hide
 ```
@@ -79,7 +79,7 @@ Analytical solutions are implemented in [Antique.jl](https://ohno.github.io/Anti
 ```@example example
 # solve
 using TwoBody
-H = Hamiltonian(NonRelativisticKinetic(1,1), CoulombPotential(-1))
+H = Hamiltonian(Kinetic(1, 1), Coulomb(-1))
 FDM = FiniteDifferenceMethod()
 res = solve(H, FDM, info=0, nₘₐₓ=4)
 
@@ -134,7 +134,7 @@ Analytical solutions are implemented in [spherical oscillator](https://ohno.gith
 ```@example example
 # solve
 using TwoBody
-H = Hamiltonian(NonRelativisticKinetic(1,1), PowerLawPotential(coefficient=1/2,exponent=2))
+H = Hamiltonian(Kinetic(1, 1), PowerLaw(coefficient=1/2, exponent=2))
 FDM = FiniteDifferenceMethod(rₘₐₓ=10.0)
 res = solve(H, FDM, info=0, nₘₐₓ=4)
 
@@ -190,6 +190,6 @@ TwoBody.FiniteDifferenceMethod
 TwoBody.solve(hamiltonian::Hamiltonian, method::FiniteDifferenceMethod)
 TwoBody.matrix(o::Hamiltonian, method::FiniteDifferenceMethod)
 TwoBody.matrix(o::RestEnergy, method::FiniteDifferenceMethod)
-TwoBody.matrix(o::NonRelativisticKinetic, method::FiniteDifferenceMethod)
+TwoBody.matrix(o::Kinetic, method::FiniteDifferenceMethod)
 TwoBody.matrix(o::PotentialTerm, method::FiniteDifferenceMethod)
 ```

--- a/docs/src/Hamiltonian.md
+++ b/docs/src/Hamiltonian.md
@@ -11,18 +11,18 @@ TwoBody.Hamiltonian
 ## Operators
 
 ```@docs; canonical=false
-TwoBody.NonRelativisticKinetic
+TwoBody.Kinetic
 TwoBody.RestEnergy
 TwoBody.RelativisticCorrection
 TwoBody.RelativisticKinetic
-TwoBody.ConstantPotential   
-TwoBody.LinearPotential     
-TwoBody.CoulombPotential    
-TwoBody.PowerLawPotential   
-TwoBody.GaussianPotential   
-TwoBody.ExponentialPotential
-TwoBody.YukawaPotential     
-TwoBody.DeltaPotential      
-TwoBody.FunctionPotential   
-TwoBody.UniformGridPotential
+TwoBody.Constant
+TwoBody.Linear
+TwoBody.Coulomb
+TwoBody.PowerLaw
+TwoBody.Gaussian
+TwoBody.Exponential
+TwoBody.Yukawa
+TwoBody.Delta
+TwoBody.Custom
+TwoBody.Tabulated
 ```

--- a/docs/src/Rayleigh-Ritz.md
+++ b/docs/src/Rayleigh-Ritz.md
@@ -35,8 +35,8 @@ Define the [Hamiltoninan](@ref Hamiltonian). This is an example for the non-rela
 
 ```@example example
 H = Hamiltonian(
-  NonRelativisticKinetic(ℏ = 1 , m = 1),
-  CoulombPotential(coefficient = -1),
+  Kinetic(ℏ = 1, m = 1),
+  Coulomb(coefficient = -1),
 )
 nothing # hide
 ```
@@ -78,7 +78,7 @@ Analytical solutions are implemented in [Antique.jl](https://ohno.github.io/Anti
 ```@example example
 # solve
 using TwoBody
-H = Hamiltonian(NonRelativisticKinetic(1,1), CoulombPotential(-1))
+H = Hamiltonian(Kinetic(1, 1), Coulomb(-1))
 BS = GeometricBasisSet(SimpleGaussianBasis, 0.1, 80.0, 20)
 res = solve(H, BS)
 
@@ -132,7 +132,7 @@ Analytical solutions are implemented in [spherical oscillator](https://ohno.gith
 ```@example example
 # solve
 using TwoBody
-H = Hamiltonian(NonRelativisticKinetic(1,1), PowerLawPotential(coefficient=1/2,exponent=2))
+H = Hamiltonian(Kinetic(1, 1), PowerLaw(coefficient=1/2, exponent=2))
 BS = GeometricBasisSet(SimpleGaussianBasis, 1.0, 10.0, 20)
 res = solve(H, BS)
 
@@ -222,10 +222,10 @@ element(SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 element(o::Hamiltonian, B1::Basis, B2::Basis)
 element(o::RestEnergy, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 element(o::Laplacian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
-element(o::NonRelativisticKinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
-element(o::ConstantPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
-element(o::LinearPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
-element(o::CoulombPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
-element(o::PowerLawPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
-element(o::GaussianPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+element(o::Kinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+element(o::Constant, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+element(o::Linear, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+element(o::Coulomb, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+element(o::PowerLaw, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+element(o::Gaussian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 ```

--- a/docs/src/VMC.md
+++ b/docs/src/VMC.md
@@ -51,8 +51,8 @@ using TwoBody
 
 # Hamiltonian
 H = Hamiltonian(
-  NonRelativisticKinetic(ℏ=1, m=1),
-  CoulombPotential(coefficient=-1),
+  Kinetic(ℏ=1, m=1),
+  Coulomb(coefficient=-1),
 )
 
 # Trial wave function

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -31,8 +31,8 @@ Define the [Hamiltoninan](@ref Hamiltonian). This is an example for the non-rela
 ```
 ```@example index
 H = Hamiltonian(
-  NonRelativisticKinetic(ℏ = 1 , m = 1),
-  CoulombPotential(coefficient = -1),
+  Kinetic(ℏ = 1, m = 1),
+  Coulomb(coefficient = -1),
 )
 nothing # hide
 ```

--- a/src/DB.jl
+++ b/src/DB.jl
@@ -38,8 +38,8 @@ put!(key::AbstractString, hamiltonian::Hamiltonian, energy::Real) =
 put!(
     :hydrogen,
     Hamiltonian(
-        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
-        CoulombPotential(coefficient = -1.0),
+        Kinetic(ℏ = 1.0, m = 1.0),
+        Coulomb(coefficient = -1.0),
     ),
     -0.5,
 )
@@ -47,8 +47,8 @@ put!(
 put!(
     :positronium,
     Hamiltonian(
-        NonRelativisticKinetic(ℏ = 1.0, m = 0.5),
-        CoulombPotential(coefficient = -1.0),
+        Kinetic(ℏ = 1.0, m = 0.5),
+        Coulomb(coefficient = -1.0),
     ),
     -0.25,
 )
@@ -56,8 +56,8 @@ put!(
 put!(
     :harmonic_oscillator,
     Hamiltonian(
-        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
-        PowerLawPotential(coefficient = 0.5, exponent = 2.0),
+        Kinetic(ℏ = 1.0, m = 1.0),
+        PowerLaw(coefficient = 0.5, exponent = 2.0),
     ),
     1.5,
 )

--- a/src/FDM.jl
+++ b/src/FDM.jl
@@ -34,7 +34,7 @@ function matrix(o::RestEnergy, method::FiniteDifferenceMethod)
   return SparseArrays.spdiagm([o.m * o.c^2 for r in method.R])
 end
 
-function matrix(o::NonRelativisticKinetic, method::FiniteDifferenceMethod)
+function matrix(o::Kinetic, method::FiniteDifferenceMethod)
   D  = FiniteDifferenceMatrices.fdmatrix(Int64(length(method.R)), n=1, m=2, d=method.direction, h=method.Δr, t=typeof(method.Δr))
   D² = FiniteDifferenceMatrices.fdmatrix(Int64(length(method.R)), n=2, m=2, d=method.direction, h=method.Δr, t=typeof(method.Δr))
   return -o.ℏ^2/2/o.m * (D² + SparseArrays.spdiagm(2 ./ method.R) * D - method.l*(method.l+1) * SparseArrays.spdiagm(1 ./ method.R .^ 2))
@@ -207,7 +207,7 @@ mc^2
 """ matrix(o::RestEnergy, method::FiniteDifferenceMethod)
 
 @doc raw"""
-`matrix(o::NonRelativisticKinetic, method::FiniteDifferenceMethod)`
+`matrix(o::Kinetic, method::FiniteDifferenceMethod)`
 
 We use the shorthand notation $\psi'(r) = \frac{\mathrm{d}\psi}{\mathrm{d}r}(r)$ and $\psi''(r) = \frac{\mathrm{d}^{2}\psi}{\mathrm{d}r^{2}}(r)$. For the uniform grid spacing ($r_{i+1} = r_{i} + \Delta r$), the finite difference for the first derivative,
 
@@ -326,7 +326,7 @@ is written as
     \end{array}\right)
   \right].
 ```
-""" matrix(o::NonRelativisticKinetic, method::FiniteDifferenceMethod)
+""" matrix(o::Kinetic, method::FiniteDifferenceMethod)
 
 @doc raw"""
 `matrix(o::PotentialTerm, method::FiniteDifferenceMethod)`

--- a/src/Hamiltonian.jl
+++ b/src/Hamiltonian.jl
@@ -1,4 +1,4 @@
-export Operator, Hamiltonian, getindex, NonRelativisticKinetic, RestEnergy, RelativisticCorrection, RelativisticKinetic, ConstantPotential, LinearPotential, CoulombPotential, PowerLawPotential, GaussianPotential, ExponentialPotential, YukawaPotential, DeltaPotential, FunctionPotential, UniformGridPotential
+export Operator, Hamiltonian, getindex, Kinetic, RestEnergy, RelativisticCorrection, RelativisticKinetic, Constant, Linear, Coulomb, PowerLaw, Gaussian, Exponential, Yukawa, Delta, Custom, Tabulated
 
 # type
 
@@ -17,7 +17,7 @@ Base.@kwdef struct Laplacian <: KineticTerm
   coefficient = 1
 end
 
-Base.@kwdef struct NonRelativisticKinetic <: KineticTerm
+Base.@kwdef struct Kinetic <: KineticTerm
   ℏ = 1
   m = 1
 end
@@ -38,47 +38,47 @@ Base.@kwdef struct RelativisticKinetic <: KineticTerm
   m = 1
 end
 
-Base.@kwdef struct ConstantPotential <: PotentialTerm
+Base.@kwdef struct Constant <: PotentialTerm
   constant = 1
 end
 
-Base.@kwdef struct LinearPotential <: PotentialTerm
+Base.@kwdef struct Linear <: PotentialTerm
   coefficient = 1
 end
 
-Base.@kwdef struct CoulombPotential <: PotentialTerm
+Base.@kwdef struct Coulomb <: PotentialTerm
   coefficient = 1
 end
 
-Base.@kwdef struct PowerLawPotential <: PotentialTerm
-  coefficient = 1
-  exponent = 1
-end
-
-Base.@kwdef struct GaussianPotential <: PotentialTerm
+Base.@kwdef struct PowerLaw <: PotentialTerm
   coefficient = 1
   exponent = 1
 end
 
-Base.@kwdef struct ExponentialPotential <: PotentialTerm
+Base.@kwdef struct Gaussian <: PotentialTerm
   coefficient = 1
   exponent = 1
 end
 
-Base.@kwdef struct YukawaPotential <: PotentialTerm
+Base.@kwdef struct Exponential <: PotentialTerm
   coefficient = 1
   exponent = 1
 end
 
-Base.@kwdef struct DeltaPotential <: PotentialTerm
+Base.@kwdef struct Yukawa <: PotentialTerm
+  coefficient = 1
+  exponent = 1
+end
+
+Base.@kwdef struct Delta <: PotentialTerm
   coefficient = 1
 end
 
-Base.@kwdef struct FunctionPotential <: PotentialTerm
+Base.@kwdef struct Custom <: PotentialTerm
   f::Function
 end
 
-Base.@kwdef struct UniformGridPotential <: PotentialTerm
+Base.@kwdef struct Tabulated <: PotentialTerm
   R::StepRangeLen
   V::Array{Number,1}
 end
@@ -94,16 +94,16 @@ Base.length(H::Hamiltonian) = length(H.terms)
 
 # function
 
-V(p::ConstantPotential   , r) = p.constant
-V(p::LinearPotential     , r) = p.coefficient * r
-V(p::CoulombPotential    , r) = p.coefficient / r
-V(p::PowerLawPotential   , r) = p.coefficient * r ^ p.exponent
-V(p::GaussianPotential   , r) = p.coefficient * exp(- p.exponent * r ^ 2)
-V(p::ExponentialPotential, r) = p.coefficient * exp(- p.exponent * r)
-V(p::YukawaPotential     , r) = p.coefficient * exp(- p.exponent * r) / r
-# V(p::DeltaPotential      , r) = 
-V(p::FunctionPotential   , r) = p.f(r)
-V(p::UniformGridPotential, r) = p.V[findfirst(p.R, r)]
+V(p::Constant       , r) = p.constant
+V(p::Linear         , r) = p.coefficient * r
+V(p::Coulomb        , r) = p.coefficient / r
+V(p::PowerLaw       , r) = p.coefficient * r ^ p.exponent
+V(p::Gaussian       , r) = p.coefficient * exp(- p.exponent * r ^ 2)
+V(p::Exponential    , r) = p.coefficient * exp(- p.exponent * r)
+V(p::Yukawa         , r) = p.coefficient * exp(- p.exponent * r) / r
+# V(p::Delta          , r) =
+V(p::Custom   , r) = p.f(r)
+V(p::Tabulated, r) = p.V[findfirst(p.R, r)]
 
 # docstring
 
@@ -135,8 +135,8 @@ The Hamiltonian is the input for each solver. This is an example for the non-rel
 
 ```@example
 H = Hamiltonian(
-  NonRelativisticKinetic(ℏ =1 , m = 1),
-  CoulombPotential(coefficient = -1),
+  Kinetic(ℏ = 1, m = 1),
+  Coulomb(coefficient = -1),
 )
 ```
 """ Hamiltonian
@@ -152,11 +152,11 @@ H = Hamiltonian(
 """ Laplacian
 
 @doc raw"""
-`NonRelativisticKinetic(ℏ=1, m=1)`
+`Kinetic(ℏ=1, m=1)`
 ```math
 -\frac{\hbar^2}{2m} \nabla^2
 ```
-""" NonRelativisticKinetic
+""" Kinetic
 
 @doc raw"""
 `RestEnergy(c=1, m=1)`
@@ -192,37 +192,37 @@ Use `c = 137.035999177` (from [2022 CODATA](https://physics.nist.gov/cgi-bin/cuu
 """ RelativisticKinetic
 
 @doc raw"""
-`ConstantPotential(constant=1)`
+`Constant(constant=1)`
 ```math
 + c
 ```
 | Arguments | Symbol |
 | :-- | :-- |
 | `constant` | ``c`` |
-""" ConstantPotential
+""" Constant
 
 @doc raw"""
-`LinearPotential(coefficient=1)`
+`Linear(coefficient=1)`
 ```math
 + ar
 ```
 | Arguments | Symbol |
 | :-- | :-- |
 | `coefficient` | ``a`` |
-""" LinearPotential
+""" Linear
 
 @doc raw"""
-`CoulombPotential(coefficient=1)`
+`Coulomb(coefficient=1)`
 ```math
 + \frac{a}{r}
 ```
 | Arguments | Symbol |
 | :-- | :-- |
 | `coefficient` | ``a`` |
-""" CoulombPotential
+""" Coulomb
 
 @doc raw"""
-`PowerLawPotential(coefficient=1, exponent=1)`
+`PowerLaw(coefficient=1, exponent=1)`
 ```math
 + ar^n
 ```
@@ -230,10 +230,10 @@ Use `c = 137.035999177` (from [2022 CODATA](https://physics.nist.gov/cgi-bin/cuu
 | :-- | :-- |
 | `coefficient` | ``a`` |
 | `exponent` | ``n`` |
-""" PowerLawPotential
+""" PowerLaw
 
 @doc raw"""
-`GaussianPotential(coefficient=1, exponent=1)`
+`Gaussian(coefficient=1, exponent=1)`
 ```math
 + a \exp(- b r^2)
 ```
@@ -241,10 +241,10 @@ Use `c = 137.035999177` (from [2022 CODATA](https://physics.nist.gov/cgi-bin/cuu
 | :-- | :-- |
 | `coefficient` | ``a`` |
 | `exponent`    | ``b`` |
-""" GaussianPotential
+""" Gaussian
 
 @doc raw"""
-`ExponentialPotential(coefficient=1, exponent=1)`
+`Exponential(coefficient=1, exponent=1)`
 ```math
 + a \exp(- b r)
 ```
@@ -252,10 +252,10 @@ Use `c = 137.035999177` (from [2022 CODATA](https://physics.nist.gov/cgi-bin/cuu
 | :-- | :-- |
 | `coefficient` | ``a`` |
 | `exponent`    | ``b`` |
-""" ExponentialPotential
+""" Exponential
 
 @doc raw"""
-`YukawaPotential(coefficient=1, exponent=1)`
+`Yukawa(coefficient=1, exponent=1)`
 ```math
 + \frac{a}{r} \exp(- b r)
 ```
@@ -263,25 +263,25 @@ Use `c = 137.035999177` (from [2022 CODATA](https://physics.nist.gov/cgi-bin/cuu
 | :-- | :-- |
 | `coefficient` | ``a`` |
 | `exponent`    | ``b`` |
-""" YukawaPotential
+""" Yukawa
 
 @doc raw"""
-`DeltaPotential(coefficient=1)`
+`Delta(coefficient=1)`
 ```math
 + a δ(r)
 ```
 | Arguments | Symbol |
 | :-- | :-- |
 | `coefficient` | ``a`` |
-""" DeltaPotential
+""" Delta
 
 @doc raw"""
-`FunctionPotential(f)`
+`Custom(f)`
 ```math
 + f(r)
 ```
-""" FunctionPotential
+""" Custom
 
 @doc raw"""
-`UniformGridPotential(R, V)`
-""" UniformGridPotential
+`Tabulated(R, V)`
+""" Tabulated

--- a/src/Rayleigh-Ritz.jl
+++ b/src/Rayleigh-Ritz.jl
@@ -388,27 +388,27 @@ function element(o::Laplacian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBa
   return - 6*π^(3/2)*SGB1.a*SGB2.a/(SGB1.a+SGB2.a)^(5/2)
 end
 
-function element(o::NonRelativisticKinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+function element(o::Kinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.ℏ^2/(2*o.m) * 6*π^(3/2)*SGB1.a*SGB2.a/(SGB1.a+SGB2.a)^(5/2)
 end
 
-function element(o::ConstantPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+function element(o::Constant, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.constant * (π/(SGB1.a+SGB2.a))^(3/2)
 end
 
-function element(o::LinearPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+function element(o::Linear, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.coefficient * 2*π/(SGB1.a+SGB2.a)^2
 end
 
-function element(o::CoulombPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+function element(o::Coulomb, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.coefficient * 2*π/(SGB1.a+SGB2.a)
 end
 
-function element(o::PowerLawPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+function element(o::PowerLaw, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.coefficient * 2 * π * SpecialFunctions.gamma((o.exponent+3)/2) / (SGB1.a+SGB2.a)^((o.exponent+3)/2)
 end
 
-function element(o::GaussianPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+function element(o::Gaussian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.coefficient * (π/(o.exponent+SGB1.a+SGB2.a))^(3/2)
 end
 
@@ -557,7 +557,7 @@ Integral Formula:
 """ element(o::Laplacian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 
 @doc raw"""
-`element(o::NonRelativisticKinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
+`element(o::Kinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
 
 ## Derivation (without Green's identity)
 
@@ -700,10 +700,10 @@ Integral Formula:
   = \frac{\Gamma\left( \frac{n+1}{2} \right)}{2 b^{\frac{n+1}{2}}}
 \end{aligned}
 ```
-""" element(o::NonRelativisticKinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+""" element(o::Kinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 
 @doc raw"""
-`element(o::ConstantPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
+`element(o::Constant, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
 
 ```math
 \begin{aligned}
@@ -726,10 +726,10 @@ Integral Formula:
 ```math
 \int_0^{\infty} r^{2n} \exp \left(-a r^2\right) ~\mathrm{d}r = \frac{(2n-1)!!}{2^{n+1}} \sqrt{\frac{\pi}{a^{2n+1}}}
 ```
-""" element(o::ConstantPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+""" element(o::Constant, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 
 @doc raw"""
-`element(o::LinearPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
+`element(o::Linear, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
 
 ```math
 \begin{aligned}
@@ -751,10 +751,10 @@ Integral Formula:
 ```math
 \int_0^{\infty} r^{2n+1} \exp \left(-a r^2\right) ~\mathrm{d}r = \frac{n!}{2 a^{n+1}}
 ```
-""" element(o::LinearPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+""" element(o::Linear, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 
 @doc raw"""
-`element(o::CoulombPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
+`element(o::Coulomb, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
 
 ```math
 \begin{aligned}
@@ -776,10 +776,10 @@ Integral Formula:
 ```math
 \int_0^{\infty} r^{2n+1} \exp \left(-a r^2\right) ~\mathrm{d}r = \frac{n!}{2 a^{n+1}}
 ```
-""" element(o::CoulombPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+""" element(o::Coulomb, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 
 @doc raw"""
-`element(o::PowerLawPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
+`element(o::PowerLaw, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
 
 ```math
 \begin{aligned}
@@ -801,10 +801,10 @@ Integral Formula:
 ```math
 \int_0^{\infty} r^{n} \exp \left(-a r^2\right) ~\mathrm{d}r = \frac{\Gamma\left( \frac{n+1}{2} \right)}{2 a^{\frac{n+1}{2}}}
 ```
-""" element(o::PowerLawPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+""" element(o::PowerLaw, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 
 @doc raw"""
-`element(o::GaussianPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
+`element(o::Gaussian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`
 
 ```math
 \begin{aligned}
@@ -826,7 +826,7 @@ Integral Formula:
 ```math
 \int_0^{\infty} r^{2n} \exp \left(-a r^2\right) ~\mathrm{d}r = \frac{(2n-1)!!}{2^{n+1}} \sqrt{\frac{\pi}{a^{2n+1}}}
 ```
-""" element(o::GaussianPotential, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
+""" element(o::Gaussian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
 
 @doc raw"""
 `element(o::Hamiltonian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)`

--- a/src/VMC.jl
+++ b/src/VMC.jl
@@ -55,7 +55,7 @@ function _local_energy(term::Laplacian, wavefunction::Function, position, ψ)
   return term.coefficient * _laplacian(wavefunction, position) / ψ
 end
 
-function _local_energy(term::NonRelativisticKinetic, wavefunction::Function, position, ψ)
+function _local_energy(term::Kinetic, wavefunction::Function, position, ψ)
   return -term.ℏ^2 / (2 * term.m) * _laplacian(wavefunction, position) / ψ
 end
 

--- a/test/DB.jl
+++ b/test/DB.jl
@@ -19,8 +19,8 @@
 
     key = :temporary_test_problem
     hamiltonian = Hamiltonian(
-        NonRelativisticKinetic(ℏ = 1.0, m = 1.0),
-        CoulombPotential(coefficient = -2.0),
+        Kinetic(ℏ = 1.0, m = 1.0),
+        Coulomb(coefficient = -2.0),
     )
 
     try

--- a/test/FDM.jl
+++ b/test/FDM.jl
@@ -3,8 +3,8 @@
   # Testing Results
 
   H = Hamiltonian(
-    NonRelativisticKinetic(ℏ = 1 , m = 1),
-    CoulombPotential(coefficient = -1),
+    Kinetic(ℏ = 1, m = 1),
+    Coulomb(coefficient = -1),
   )
   FDM = FiniteDifferenceMethod(
     Δr = 0.1,

--- a/test/Hamiltonian.jl
+++ b/test/Hamiltonian.jl
@@ -1,0 +1,18 @@
+@testset "Hamiltonian.jl" begin
+  @test Kinetic() isa Operator
+
+  potentials = (
+    Constant(),
+    Linear(),
+    Coulomb(),
+    PowerLaw(),
+    Gaussian(),
+    Exponential(),
+    Yukawa(),
+    Delta(),
+    Custom(identity),
+    Tabulated(range(1.0, step=1.0, length=3), Number[1, 2, 3]),
+  )
+  @test all(p -> p isa TwoBody.PotentialTerm, potentials)
+  @test TwoBody.V(Custom(r -> r^2), 2) == 4
+end

--- a/test/Rayleigh-Ritz.jl
+++ b/test/Rayleigh-Ritz.jl
@@ -3,8 +3,8 @@
   # Testing Results
 
   H = Hamiltonian(
-    NonRelativisticKinetic(ℏ = 1 , m = 1),
-    CoulombPotential(coefficient = -1),
+    Kinetic(ℏ = 1, m = 1),
+    Coulomb(coefficient = -1),
   )
   BS = BasisSet(
     SimpleGaussianBasis(13.00773),
@@ -75,7 +75,7 @@
   @testset "element()" begin
 
     # kinetic terms
-    o = NonRelativisticKinetic(ℏ=1, m=1)
+    o = Kinetic(ℏ=1, m=1)
     println(o)
     println("  i  j\tnumerical  \tanalytical")
     l = 0
@@ -96,16 +96,16 @@
 
     # potential terms
     for o in [
-      ConstantPotential(),
-      LinearPotential(),
-      CoulombPotential(),
-      PowerLawPotential(),
-      PowerLawPotential(exponent=2),
-      GaussianPotential(),
-      # ExponentialPotential(),
-      # YukawaPotential(),
-      # LogarithmicPotential(),
-      # DeltaPotential(),
+      Constant(),
+      Linear(),
+      Coulomb(),
+      PowerLaw(),
+      PowerLaw(exponent=2),
+      Gaussian(),
+      # Exponential(),
+      # Yukawa(),
+      # Logarithmic(),
+      # Delta(),
     ]
       println(o)
       println("  i  j\tnumerical  \tanalytical")

--- a/test/VMC.jl
+++ b/test/VMC.jl
@@ -13,8 +13,8 @@
 
   @testset "local energy" begin
     H = Hamiltonian(
-      NonRelativisticKinetic(ℏ=1, m=1),
-      PowerLawPotential(coefficient=1 / 2, exponent=2),
+      Kinetic(ℏ=1, m=1),
+      PowerLaw(coefficient=1 / 2, exponent=2),
     )
     ψ(r) = exp(-sum(abs2, r) / 2)
 
@@ -28,8 +28,8 @@
 
   @testset "harmonic oscillator" begin
     H = Hamiltonian(
-      NonRelativisticKinetic(ℏ=1, m=1),
-      PowerLawPotential(coefficient=1 / 2, exponent=2),
+      Kinetic(ℏ=1, m=1),
+      PowerLaw(coefficient=1 / 2, exponent=2),
     )
     ψ(r) = exp(-sum(abs2, r) / 2)
     method = VariationalMonteCarlo(
@@ -53,8 +53,8 @@
     @test mean_radius_squared ≈ 1.5 atol=0.5
 
     singular_H = Hamiltonian(
-      NonRelativisticKinetic(ℏ=1, m=1),
-      FunctionPotential(f=r -> r < 1 ? Inf : r^2 / 2),
+      Kinetic(ℏ=1, m=1),
+      Custom(f=r -> r < 1 ? Inf : r^2 / 2),
     )
     singular_result = solve(
       singular_H,
@@ -70,8 +70,8 @@
 
   @testset "multiple walkers" begin
     H = Hamiltonian(
-      NonRelativisticKinetic(ℏ=1, m=1),
-      PowerLawPotential(coefficient=1 / 2, exponent=2),
+      Kinetic(ℏ=1, m=1),
+      PowerLaw(coefficient=1 / 2, exponent=2),
     )
     ψ(r) = exp(-sum(abs2, r) / 2)
     method = VariationalMonteCarlo(
@@ -103,8 +103,8 @@
 
   @testset "Coulomb singularity" begin
     H = Hamiltonian(
-      NonRelativisticKinetic(ℏ=1, m=1),
-      CoulombPotential(coefficient=-1),
+      Kinetic(ℏ=1, m=1),
+      Coulomb(coefficient=-1),
     )
     α = 0.2829
     ψ(r) = exp(-α * sum(abs2, r))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using SpecialFunctions
 using ForwardDiff
 
 @testset verbose = true "TwoBody.jl" begin
+  include("Hamiltonian.jl")
   include("DB.jl")
   include("Basis.jl")
   include("Rayleigh-Ritz.jl")


### PR DESCRIPTION
## Summary

- simplify Hamiltonian operator names such as `NonRelativisticKinetic` to `Kinetic` and `CoulombPotential` to `Coulomb`
- use concise representation names `Custom` and `Tabulated` for user-defined potentials
- update Rayleigh–Ritz, FDM, VMC, the benchmark database, documentation, and tests to use the new API
- add focused constructor and potential-evaluation coverage for the renamed operator types

## Why

The previous API mixed verbose implementation-oriented names with mathematical names. The new naming scheme uses concise mathematical names for built-in operators and concise representation names for user-supplied potentials.

## Impact

This is a breaking public API rename. The previous operator type names are removed rather than retained as aliases.

## Validation

- `julia --project=. -e "using Pkg; Pkg.test()"`
- 307 tests passed, including 33 VMC tests
- `git diff --check`
- verified that no previous operator names remain in source, tests, or documentation

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.