### PR TITLE
Fix documentation deployment after repository transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# TwoBody.jl [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://ohno.github.io/TwoBody.jl/stable) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://ohno.github.io/TwoBody.jl/dev) [![Build Status](https://github.com/ohno/TwoBody.jl/workflows/CI/badge.svg)](https://github.com/ohno/TwoBody.jl/actions)
+# TwoBody.jl [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliafewbody.github.io/TwoBody.jl/stable) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliafewbody.github.io/TwoBody.jl/dev) [![Build Status](https://github.com/JuliaFewBody/TwoBody.jl/workflows/CI/badge.svg)](https://github.com/JuliaFewBody/TwoBody.jl/actions)
 
 TwoBody.jl: a Julia package for quantum mechanical two-body problems
 
 ## Documentation 
 
-https://ohno.github.io/TwoBody.jl/dev/
+https://juliafewbody.github.io/TwoBody.jl/dev/
 
 ## Dependency
 
@@ -32,7 +32,7 @@ flowchart TD
 There are several tools for developers.
 
 ```sh
-git clone https://github.com/ohno/TwoBody.jl.git
+git clone https://github.com/JuliaFewBody/TwoBody.jl.git
 cd TwoBody.jl
 julia
 julia> include("dev/revice.jl")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,11 +6,11 @@ DocMeta.setdocmeta!(TwoBody, :DocTestSetup, :(using TwoBody); recursive=true)
 makedocs(;
     modules=[TwoBody],
     authors="Shuhei Ohno",
-    repo="https://github.com/ohno/TwoBody.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/JuliaFewBody/TwoBody.jl/blob/{commit}{path}#{line}",
     sitename="TwoBody.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://ohno.github.io/TwoBody.jl",
+        canonical="https://juliafewbody.github.io/TwoBody.jl/",
         assets=String[
             "./assets/logo.ico",
         ],
@@ -27,5 +27,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/ohno/TwoBody.jl",
+    repo="github.com/JuliaFewBody/TwoBody.jl",
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,16 +4,16 @@ CurrentModule = TwoBody
 
 # TwoBody.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://ohno.github.io/TwoBody.jl/stable) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://ohno.github.io/TwoBody.jl/dev) [![Build Status](https://github.com/ohno/TwoBody.jl/workflows/CI/badge.svg)](https://github.com/ohno/TwoBody.jl/actions)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliafewbody.github.io/TwoBody.jl/stable) [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliafewbody.github.io/TwoBody.jl/dev) [![Build Status](https://github.com/JuliaFewBody/TwoBody.jl/workflows/CI/badge.svg)](https://github.com/JuliaFewBody/TwoBody.jl/actions)
 
-[TwoBody.jl](https://github.com/ohno/TwoBody.jl): a Julia package for quantum mechanical two-body problems
+[TwoBody.jl](https://github.com/JuliaFewBody/TwoBody.jl): a Julia package for quantum mechanical two-body problems
 
 ## Install
 
 Run the following code on the REPL or Jupyter Notebook to install this package.
 
 ```julia
-import Pkg; Pkg.add(url="https://github.com/ohno/TwoBody.jl.git")
+import Pkg; Pkg.add(url="https://github.com/JuliaFewBody/TwoBody.jl.git")
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- point Documenter deployment and canonical URLs at `JuliaFewBody/TwoBody.jl`
- update README and documentation links that still referenced the previous owner
- keep external `Antique.jl` links unchanged

## Root cause

The repository was transferred from `ohno/TwoBody.jl` to `JuliaFewBody/TwoBody.jl`, but `deploydocs` still targeted the old repository. Documenter therefore rejected deployment because `GITHUB_REPOSITORY=JuliaFewBody/TwoBody.jl` did not match `repo=github.com/ohno/TwoBody.jl`, while the GitHub Actions job still reported success.

## Impact

Documentation builds from `main` can deploy to the existing `gh-pages` branch again, and published links now point to `https://juliafewbody.github.io/TwoBody.jl/`.

## Validation

- `git diff --check`
- verified no stale `ohno.github.io/TwoBody.jl` or `github.com/ohno/TwoBody.jl` references remain in README, docs, or workflow files
- local Documenter build not run because Julia is not installed in the local environment; the PR Documentation job provides the runtime validation

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.