### PR TITLE
Make database documentation examples executable

### DIFF
--- a/docs/src/DB.md
+++ b/docs/src/DB.md
@@ -11,25 +11,26 @@ intended for package development.
 
 ## Usage
 
+```@example db-usage
+using TwoBody
+```
+
 Retrieve a benchmark using its key:
 
-```julia-repl
-julia> entry = TwoBody.db(:hydrogen)
-
-julia> entry.hamiltonian
-
-julia> entry.energy
+```@repl db-usage
+entry = TwoBody.db(:hydrogen)
+entry.hamiltonian
+entry.energy
 ```
 
 Add a benchmark using `TwoBody.put!`:
 
-```julia-repl
-julia> hamiltonian = Hamiltonian(
-           Kinetic(ℏ = 1.0, m = 1.0),
-           Coulomb(coefficient = -1.0),
-       )
-
-julia> TwoBody.put!(:example, hamiltonian, -0.5)
+```@repl db-usage
+hamiltonian = Hamiltonian(
+    Kinetic(ℏ = 1.0, m = 1.0),
+    Coulomb(coefficient = -1.0),
+)
+TwoBody.put!(:example, hamiltonian, -0.5)
 ```
 
 Duplicate keys are rejected, and Hamiltonians are copied on registration and


### PR DESCRIPTION
## Summary

- make the database usage examples executable with a shared Documenter session
- render the lookup and registration results as REPL output
- use the current `Kinetic` and `Coulomb` Hamiltonian API from the latest `main`

## Validation

- built the complete documentation site locally with Documenter
- confirmed that `docs/build/DB.html` contains the evaluated database entries, Hamiltonian, energy, and `put!` result

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.