### PR TITLE
Prepare v0.0.11 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,74 @@
+# TwoBody.jl release notes
+
+## v0.1.0 — 2026-08-10
+
+TwoBody.jl v0.1.0 adds variational Monte Carlo calculations and a benchmark
+Hamiltonian database, improves the Rayleigh–Ritz workflow, and simplifies the
+public operator API. This release contains breaking API changes; see the
+migration notes below.
+
+### Highlights
+
+- Added `VariationalMonteCarlo` with symmetric Metropolis sampling, burn-in,
+  thinning, multiple walkers, reproducible random-number generation, sampling
+  diagnostics, and ForwardDiff-based local-energy evaluation.
+- Added a benchmark Hamiltonian database with lookup and registration support
+  for reusable physical systems.
+- Improved Rayleigh–Ritz results and examples, including updated Antique.jl
+  integration.
+- Added tested VMC and database guides and made database examples executable in
+  Documenter.
+
+### Breaking changes
+
+Hamiltonian operator types now use concise mathematical names. The old names
+have been removed rather than retained as aliases:
+
+| Before | v0.1.0 |
+| --- | --- |
+| `NonRelativisticKinetic` | `Kinetic` |
+| `ConstantPotential` | `Constant` |
+| `LinearPotential` | `Linear` |
+| `CoulombPotential` | `Coulomb` |
+| `PowerLawPotential` | `PowerLaw` |
+| `GaussianPotential` | `Gaussian` |
+| `ExponentialPotential` | `Exponential` |
+| `YukawaPotential` | `Yukawa` |
+| `DeltaPotential` | `Delta` |
+| `FunctionPotential` | `Custom` |
+| `UniformGridPotential` | `Tabulated` |
+
+For example, update
+
+```julia
+Hamiltonian(
+  NonRelativisticKinetic(ℏ=1, m=1),
+  CoulombPotential(coefficient=-1),
+)
+```
+
+to
+
+```julia
+Hamiltonian(
+  Kinetic(ℏ=1, m=1),
+  Coulomb(coefficient=-1),
+)
+```
+
+### Compatibility and maintenance
+
+- Updated Antique.jl examples and tests for Antique.jl 0.15.
+- Fixed documentation deployment after the repository moved to the
+  `JuliaFewBody` organization.
+- Updated stable, development, repository, and documentation links for the new
+  repository location.
+
+### Included pull requests
+
+- #16 — Add the benchmark Hamiltonian database.
+- #19 — Update Antique.jl test API usage.
+- #22 — Add variational Monte Carlo.
+- #23 — Simplify Hamiltonian operator names.
+- #24 — Fix documentation deployment after the repository transfer.
+- #25 — Make database documentation examples executable.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TwoBody"
 uuid = "a92d7657-722c-45a6-9d18-9da4c8a753b6"
 authors = ["Shuhei Ohno"]
-version = "0.0.10"
+version = "0.1.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"


### PR DESCRIPTION
## Summary

- bump the package version from `0.0.10` to `0.0.11`
- add comprehensive release notes for all changes since `v0.0.9`
- document the breaking Hamiltonian operator renames and provide a migration example

## Why v0.0.11

The package version had already been advanced to `0.0.10` before the current release preparation. This pull request advances the current package state to the intended next release, `v0.0.11`.

## Release highlights

- variational Monte Carlo with multiple walkers, burn-in, thinning, diagnostics, and ForwardDiff local energies
- benchmark Hamiltonian database
- improved Rayleigh–Ritz results and Antique.jl 0.15 compatibility
- concise Hamiltonian operator names
- repaired documentation deployment and executable database examples

## Scope

This release PR is based on the latest merged `main`. Draft PR #27 (`ℏ` to `hbar`) is not included because it has not been merged.

## Validation

- `git diff --check` passes
- `Project.toml` parses successfully and reports version `0.0.11`
- Julia tests were not run locally because Julia is unavailable in the current environment; the PR CI provides runtime validation
