### PR TITLE
Add Hamiltonian-aware free complement method

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,6 +20,7 @@ makedocs(;
         "Hamiltonian" => "Hamiltonian.md",
         "Database" => "DB.md",
         "Rayleigh-Ritz Method" => "Rayleigh-Ritz.md",
+        "Free Complement Method" => "Free-Complement.md",
         "Finite Difference Method" => "FDM.md",
         "Variational Monte Carlo" => "VMC.md",
         "API reference" => "API.md",

--- a/docs/src/Free-Complement.md
+++ b/docs/src/Free-Complement.md
@@ -1,0 +1,186 @@
+```@meta
+CurrentModule = TwoBody
+```
+
+# Free Complement Method
+
+The Free Complement (FC) method systematically improves a trial wave function
+by generating functions from the Schrödinger equation. Starting from
+``\psi_n``, one iteration is
+
+```math
+\psi_{n+1} = \left[1 + C_n g(H-E_n)\right]\psi_n,
+```
+
+where ``g`` is a scaling function that regularizes singular terms. The general
+theory is described by Nakatsuji [1].
+
+!!! note
+    TwoBody.jl implements `FC` for `PowerSlaterBasis`. For an s-wave hydrogen Hamiltonian and the default ``g(r)=r``, it generates the basis-function forms in ``g(H-E_n)``, removes duplicates, and discards functions singular at the origin. The coefficients ``C_n`` are determined variationally by the existing Rayleigh–Ritz solver, whose analytic matrix elements for this basis cover the `Kinetic` and `Coulomb` terms used in the example below.
+
+## Theory
+
+This procedure can be interpreted as an algorithm for generating basis
+functions. Consider the basis function ``\phi(r)=r^n\mathrm{e}^{-ar}``. When
+the Hamiltonian acts on it,
+
+```math
+\begin{aligned}
+\hat{H} \phi(r)
+=&
+- \frac{1}{2} \frac{\partial^2 \phi}{{\partial r}^2}(r)
+- \frac{1}{r} \frac{\partial\phi}{\partial r}(r)
+- \frac{1}{r} \phi(r) \\
+=
+&- \frac{1}{2} a^2 r^n \mathrm{e}^{-ar}
+ + a n r^{n-1} \mathrm{e}^{-ar}
+ - \frac{1}{2} n(n-1)r^{n-2} \mathrm{e}^{-ar} \\
+&- a r^{n-1} \mathrm{e}^{-ar}
+ + n r^{n-2} \mathrm{e}^{-ar}
+ - r^{n-1} \mathrm{e}^{-ar} \\
+\end{aligned}
+```
+
+the expression splits into several terms. Their coefficients are not important
+for generating the basis. What matters is that the following three basis
+functions are obtained:
+
+```math
+r^n \mathrm{e}^{-ar} \\
+r^{n-1} \mathrm{e}^{-ar} \\
+r^{n-2} \mathrm{e}^{-ar}
+```
+
+Thus, when the coefficients are ignored, it is easy to predict which basis
+functions will be generated. However, basis functions that diverge at ``r=0``
+are removed, so generating ``r^{n+1}`` is preferable to generating
+``r^{n-1}``. Multiplication by ``g(r)=r`` gives the following three basis
+functions:
+
+```math
+r^{n+1} \mathrm{e}^{-ar} \\
+r^{n  } \mathrm{e}^{-ar} \\
+r^{n-1} \mathrm{e}^{-ar}
+```
+
+These include newly generated basis functions that do not diverge. Starting
+from ``\phi(r)=\mathrm{e}^{-ar}``, the nonsingular basis functions increase as
+follows:
+
+```math
+\mathrm{e}^{-ar} \\
+\Downarrow \\
+\mathrm{e}^{-ar} \\
+r \mathrm{e}^{-ar} \\
+\Downarrow \\
+\mathrm{e}^{-ar} \\
+r \mathrm{e}^{-ar} \\
+r^2 \mathrm{e}^{-ar} \\
+\Downarrow \\
+\mathrm{e}^{-ar} \\
+r \mathrm{e}^{-ar} \\
+r^2 \mathrm{e}^{-ar} \\
+r^3 \mathrm{e}^{-ar} \\
+\Downarrow \\
+\vdots
+```
+
+The implementation only needs to encode this rule.
+
+## Usage
+
+The following REPL session shows how repeated application of `FC` expands a
+power-Slater basis set:
+
+```@repl fc-basis-generation
+using TwoBody
+H = Hamiltonian(
+  Kinetic(hbar = 1, m = 1),
+  Coulomb(coefficient = -1),
+)
+BS = BasisSet(PowerSlaterBasis(0, 1.5))
+FC(H, BS)
+FC(H, FC(H, BS))
+FC(H, FC(H, FC(H, BS)))
+```
+
+### Example of Hydrogen Atom
+
+Define the non-relativistic hydrogen Hamiltonian in atomic units and start from
+``e^{-1.5r}``:
+
+```@example fc
+using TwoBody
+
+H = Hamiltonian(
+  Kinetic(hbar = 1, m = 1),
+  Coulomb(coefficient = -1),
+)
+
+basisset = BasisSet(PowerSlaterBasis(0, 1.5))
+nothing # hide
+```
+
+At each iteration, solve the generalized eigenvalue problem and generate the
+next complement. The table compares the resulting variational energies with
+the reference values:
+
+```@example fc
+using Printf
+
+reference_energies = [
+  "-0.375",
+  "-0.491 025 404",
+  "-0.499 316 143",
+  "-0.499 954 132",
+  "-0.499 997 229",
+  "-0.499 999 844",
+  "-0.499 999 992",
+  "-0.500 000 000",
+  "-0.500 000 000",
+]
+@printf("%5s  %-18s  %s\n", "M_n", "This work", "Ref.")
+println("-----  ------------------  ------------")
+for reference_energy in reference_energies
+  result = solve(H, basisset, info=-1)
+  @printf(
+    "%5d  %18.15f  %s\n",
+    length(basisset),
+    result.E[1],
+    reference_energy,
+  )
+  global basisset = FC(H, basisset)
+end
+```
+
+You can also generate a complement from one basis function:
+
+```@repl fc-single
+using TwoBody
+H = Hamiltonian(
+  Kinetic(hbar = 1, m = 1),
+  Coulomb(coefficient = -1),
+)
+FC(H, PowerSlaterBasis(0, 1.5))
+```
+
+## Acknowledgments
+
+This work was developed on the basis of the fourth lecture in Section I of the
+[64th Summer School of the Young Researchers’ Association for Molecular
+Science](https://www.natsugaku2025.ymsa.jp/home), held in Kanazawa on August
+20, 2025. The authors gratefully acknowledge Professor Hiroshi Nakatsuji and
+all those involved in organizing the summer school for their contributions and
+support.
+
+## Bibliography
+
+1. H. Nakatsuji, “Scaled Schrödinger Equation and the Exact Wave Function,”
+   [*Phys. Rev. Lett.* **93**, 030403 (2004)](https://doi.org/10.1103/PhysRevLett.93.030403).
+
+## API reference
+
+```@docs; canonical=false
+PowerSlaterBasis
+FC
+```

--- a/src/Basis.jl
+++ b/src/Basis.jl
@@ -1,4 +1,4 @@
-export BasisSet, Basis, GeometricBasisSet, PrimitiveBasis, ContractedBasis, SimpleGaussianBasis, GaussianBasis
+export BasisSet, Basis, GeometricBasisSet, PrimitiveBasis, ContractedBasis, SimpleGaussianBasis, GaussianBasis, PowerSlaterBasis, FC
 
 # type
 
@@ -38,6 +38,11 @@ Base.@kwdef struct SimpleGaussianBasis <: PrimitiveBasis
   a = 1
 end
 
+Base.@kwdef struct PowerSlaterBasis <: PrimitiveBasis
+  n::Int = 0
+  a::Real = 1
+end
+
 Base.@kwdef struct GaussianBasis <: PrimitiveBasis
   a = 1
   l = 0
@@ -63,8 +68,70 @@ Base.length(GBS::GeometricBasisSet) = length(GBS.basis)
 # function
 
 φ(b::SimpleGaussianBasis, r) = exp(-b.a*r^2)
+φ(b::PowerSlaterBasis, r) = r^b.n * exp(-b.a*r)
 φ(b::GaussianBasis, r, θ, φ) = N(b.l) * r^b.l * exp(-b.a*r^2) * Y(b.l, b.m, θ, φ)
 φ(b::ContractedBasis, r, θ, φ) = sum(b.c[i] * φ(b.φ[i], r, θ, φ) for i in 1:length(b.c))
+
+_multiply(basis::PowerSlaterBasis, g::PowerSlaterBasis) =
+  PowerSlaterBasis(basis.n + g.n, basis.a + g.a)
+
+function _laplacian_candidates(basis::PowerSlaterBasis)
+  candidates = PowerSlaterBasis[]
+  !iszero(basis.a^2) && push!(candidates, PowerSlaterBasis(basis.n, basis.a))
+  !iszero(2*basis.a*(basis.n+1)) && push!(candidates, PowerSlaterBasis(basis.n-1, basis.a))
+  !iszero(basis.n*(basis.n+1)) && push!(candidates, PowerSlaterBasis(basis.n-2, basis.a))
+  return candidates
+end
+
+_fc_candidates(o::Laplacian, basis::PowerSlaterBasis) =
+  iszero(o.coefficient) ? PowerSlaterBasis[] : _laplacian_candidates(basis)
+_fc_candidates(o::Kinetic, basis::PowerSlaterBasis) =
+  iszero(o.hbar) ? PowerSlaterBasis[] : _laplacian_candidates(basis)
+_fc_candidates(o::RestEnergy, basis::PowerSlaterBasis) =
+  iszero(o.m * o.c^2) ? PowerSlaterBasis[] : PowerSlaterBasis[basis]
+_fc_candidates(o::Constant, basis::PowerSlaterBasis) =
+  iszero(o.constant) ? PowerSlaterBasis[] : PowerSlaterBasis[basis]
+_fc_candidates(o::Linear, basis::PowerSlaterBasis) =
+  iszero(o.coefficient) ? PowerSlaterBasis[] : PowerSlaterBasis[PowerSlaterBasis(basis.n+1, basis.a)]
+_fc_candidates(o::Coulomb, basis::PowerSlaterBasis) =
+  iszero(o.coefficient) ? PowerSlaterBasis[] : PowerSlaterBasis[PowerSlaterBasis(basis.n-1, basis.a)]
+
+function _fc_candidates(o::PowerLaw, basis::PowerSlaterBasis)
+  iszero(o.coefficient) && return PowerSlaterBasis[]
+  isinteger(o.exponent) || throw(ArgumentError(
+    "FC requires an integer PowerLaw exponent for PowerSlaterBasis, got $(o.exponent)",
+  ))
+  return PowerSlaterBasis[PowerSlaterBasis(basis.n + Int(o.exponent), basis.a)]
+end
+
+_fc_candidates(o::Exponential, basis::PowerSlaterBasis) =
+  iszero(o.coefficient) ? PowerSlaterBasis[] : PowerSlaterBasis[PowerSlaterBasis(basis.n, basis.a + o.exponent)]
+_fc_candidates(o::Yukawa, basis::PowerSlaterBasis) =
+  iszero(o.coefficient) ? PowerSlaterBasis[] : PowerSlaterBasis[PowerSlaterBasis(basis.n-1, basis.a + o.exponent)]
+
+function _fc_candidates(o::Operator, ::PowerSlaterBasis)
+  throw(ArgumentError("FC does not support $(typeof(o)) with PowerSlaterBasis"))
+end
+
+function FC(hamiltonian::Hamiltonian, basis::PowerSlaterBasis; g::PowerSlaterBasis=PowerSlaterBasis(1, 0))
+  candidates = PowerSlaterBasis[basis] # the -Eₙ term in g(H-Eₙ)φ
+  for operator in hamiltonian.terms
+    append!(candidates, _fc_candidates(operator, basis))
+  end
+  complements = unique(_multiply(candidate, g) for candidate in candidates)
+  return BasisSet(filter(candidate -> isfinite(φ(candidate, 0.0)), complements)...)
+end
+
+function FC(hamiltonian::Hamiltonian, basisset::BasisSet; g::PowerSlaterBasis=PowerSlaterBasis(1, 0))
+  complements = PowerSlaterBasis[]
+  for basis in basisset.basis
+    basis isa PowerSlaterBasis || throw(ArgumentError(
+      "FC only supports BasisSet entries of type PowerSlaterBasis, got $(typeof(basis))",
+    ))
+    append!(complements, FC(hamiltonian, basis; g=g).basis)
+  end
+  return BasisSet(unique(complements)...)
+end
 
 # function for testing
 
@@ -315,6 +382,37 @@ r^{2}
 k^l e^{-\frac{k^2}{4\alpha}}
 ```
 """ SimpleGaussianBasis
+
+@doc raw"""
+`PowerSlaterBasis(n=0, a=1)`
+
+An unnormalized power-Slater basis function for an s wave:
+```math
+\phi_{n,a}(r) = r^n \exp(-ar).
+```
+
+`n` is an integer power and `a` is the exponential parameter. For a
+square-integrable basis function, choose parameters for which the required
+matrix elements are finite (normally ``n \ge 0`` and ``a > 0``).
+""" PowerSlaterBasis
+
+@doc raw"""
+`FC(hamiltonian, basis; g=PowerSlaterBasis(1, 0))`
+
+Generate the next Free Complement basis from a `PowerSlaterBasis` or a
+`BasisSet` of power-Slater functions by collecting the basis-function forms in
+``g(H-E_n)\phi``. Numerical coefficients are ignored. The default scaling
+function is ``g(r)=r``. Duplicate functions and functions singular at the
+origin are removed.
+
+The Hamiltonian may contain `Kinetic`, `Laplacian`, `RestEnergy`, `Constant`,
+`Linear`, `Coulomb`, integer-exponent `PowerLaw`, `Exponential`, and `Yukawa`
+terms. An `ArgumentError` is thrown when an operator does not map a
+`PowerSlaterBasis` to power-Slater functions.
+
+For the hydrogen Hamiltonian, repeated application starting from
+`PowerSlaterBasis(0, 1.5)` adds one power of ``r`` at each iteration.
+""" FC
 
 @doc raw"""
 `GaussianBasis(a=1, l=0, m=0)`

--- a/src/Rayleigh-Ritz.jl
+++ b/src/Rayleigh-Ritz.jl
@@ -380,6 +380,10 @@ function element(SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return (π/(SGB1.a+SGB2.a))^(3/2)
 end
 
+function element(PSB1::PowerSlaterBasis, PSB2::PowerSlaterBasis)
+  return 4 * π * SpecialFunctions.gamma(PSB1.n+PSB2.n+3) / (PSB1.a+PSB2.a)^(PSB1.n+PSB2.n+3)
+end
+
 function element(o::RestEnergy, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.m * o.c^2 * (π/(SGB1.a+SGB2.a))^(3/2)
 end
@@ -392,6 +396,14 @@ function element(o::Kinetic, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasi
   return o.hbar^2/(2*o.m) * 6*π^(3/2)*SGB1.a*SGB2.a/(SGB1.a+SGB2.a)^(5/2)
 end
 
+function element(o::Kinetic, PSB1::PowerSlaterBasis, PSB2::PowerSlaterBasis)
+  return - o.hbar^2/(2*o.m) * 4 * π * (
+        PSB2.n*(PSB2.n+1) * SpecialFunctions.gamma(PSB1.n+PSB2.n+1) / (PSB1.a+PSB2.a)^(PSB1.n+PSB2.n+1)
+    - 2*PSB2.a*(PSB2.n+1) * SpecialFunctions.gamma(PSB1.n+PSB2.n+2) / (PSB1.a+PSB2.a)^(PSB1.n+PSB2.n+2)
+    +            PSB2.a^2 * SpecialFunctions.gamma(PSB1.n+PSB2.n+3) / (PSB1.a+PSB2.a)^(PSB1.n+PSB2.n+3)
+    )
+end
+
 function element(o::Constant, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.constant * (π/(SGB1.a+SGB2.a))^(3/2)
 end
@@ -402,6 +414,10 @@ end
 
 function element(o::Coulomb, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.coefficient * 2*π/(SGB1.a+SGB2.a)
+end
+
+function element(o::Coulomb, PSB1::PowerSlaterBasis, PSB2::PowerSlaterBasis)
+  return o.coefficient * 4 * π * SpecialFunctions.gamma(PSB1.n+PSB2.n+2) / (PSB1.a+PSB2.a)^(PSB1.n+PSB2.n+2)
 end
 
 function element(o::PowerLaw, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)

--- a/test/FC.jl
+++ b/test/FC.jl
@@ -1,0 +1,81 @@
+@testset "Free Complement" begin
+  basis = PowerSlaterBasis(0, 1.5)
+  @test TwoBody.φ(basis, 2.0) ≈ exp(-3.0)
+
+  hamiltonian = Hamiltonian(
+    Kinetic(hbar = 1, m = 1),
+    Coulomb(coefficient = -1),
+  )
+
+  first_complement = FC(hamiltonian, basis)
+  @test [b.n for b in first_complement.basis] == [1, 0]
+  @test all(b.a == 1.5 for b in first_complement.basis)
+
+  second_complement = FC(hamiltonian, first_complement)
+  @test [b.n for b in second_complement.basis] == [2, 1, 0]
+  @test all(isfinite(TwoBody.φ(b, 0.0)) for b in second_complement.basis)
+  @test_throws MethodError FC(basis)
+
+  coulomb_complement = FC(
+    Hamiltonian(Coulomb(coefficient = -1)),
+    PowerSlaterBasis(1, 1.5),
+  )
+  @test [b.n for b in coulomb_complement.basis] == [2, 1]
+
+  powerlaw_complement = FC(
+    Hamiltonian(PowerLaw(coefficient = 1, exponent = 2)),
+    basis,
+  )
+  @test [b.n for b in powerlaw_complement.basis] == [1, 3]
+  @test_throws ArgumentError FC(
+    Hamiltonian(PowerLaw(coefficient = 1, exponent = 0.5)),
+    basis,
+  )
+  @test_throws ArgumentError FC(Hamiltonian(Gaussian()), basis)
+  @test_throws ArgumentError FC(
+    hamiltonian,
+    BasisSet(basis, SimpleGaussianBasis(1.0)),
+  )
+
+  bra = PowerSlaterBasis(1, 1.2)
+  ket = PowerSlaterBasis(2, 0.8)
+  overlap = 4π * quadgk(r -> r^2 * TwoBody.φ(bra, r) * TwoBody.φ(ket, r), 0, Inf)[1]
+  @test TwoBody.element(bra, ket) ≈ overlap
+
+  kinetic = Kinetic(hbar = 1, m = 1)
+  dφ(r) = ForwardDiff.derivative(x -> TwoBody.φ(ket, x), r)
+  d²φ(r) = ForwardDiff.derivative(dφ, r)
+  kinetic_integral = 4π * quadgk(
+    r -> r^2 * TwoBody.φ(bra, r) * (-1/2 * (d²φ(r) + 2/r*dφ(r))),
+    0,
+    Inf,
+  )[1]
+  @test TwoBody.element(kinetic, bra, ket) ≈ kinetic_integral
+  @test TwoBody.element(kinetic, bra, ket) ≈ TwoBody.element(kinetic, ket, bra)
+
+  coulomb = Coulomb(coefficient = -1)
+  coulomb_integral = 4π * quadgk(
+    r -> r^2 * TwoBody.φ(bra, r) * TwoBody.V(coulomb, r) * TwoBody.φ(ket, r),
+    0,
+    Inf,
+  )[1]
+  @test TwoBody.element(coulomb, bra, ket) ≈ coulomb_integral
+
+  basisset = BasisSet(basis)
+  expected = [
+    -0.375000000000000,
+    -0.491025403784439,
+    -0.499316142679167,
+    -0.499954132454839,
+    -0.499997229001983,
+    -0.499999844138451,
+  ]
+  energies = Float64[]
+  for _ in eachindex(expected)
+    push!(energies, solve(hamiltonian, basisset, info=-1).E[1])
+    basisset = FC(hamiltonian, basisset)
+  end
+
+  @test energies ≈ expected atol=5e-13
+  @test issorted(energies; rev=true)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using ForwardDiff
   include("Hamiltonian.jl")
   include("DB.jl")
   include("Basis.jl")
+  include("FC.jl")
   include("Rayleigh-Ritz.jl")
   include("FDM.jl")
   include("VMC.jl")


### PR DESCRIPTION
## Summary

- add `PowerSlaterBasis` and Hamiltonian-aware `FC(H, ...)` basis generation
- add analytic overlap, kinetic, and Coulomb matrix elements for the power-Slater basis
- add Free Complement tests, theory, usage, and hydrogen convergence documentation

## Why

This implements the Free Complement method requested in #30. The Hamiltonian is passed explicitly so generated basis functions reflect its operators, while unsupported operator/basis combinations fail clearly.

Closes #30.

## Impact

Users can iteratively generate nonsingular power-Slater complements and solve the resulting Rayleigh–Ritz problem. The documentation includes the basis-generation rule and a comparison of hydrogen ground-state convergence with reference values.

## Validation

- `julia --startup-file=no --project=. -e "using Pkg; Pkg.test()"` — 324 tests passed
- `julia --startup-file=no --project=docs docs/make.jl` — Documenter build succeeded

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.
