### PR TITLE
Add contracted basis function support

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,6 +26,8 @@ makedocs(;
     ],
 )
 
-deploydocs(;
-    repo="github.com/JuliaFewBody/TwoBody.jl",
-)
+if get(ENV, "CI", "false") == "true"
+    deploydocs(;
+        repo="github.com/JuliaFewBody/TwoBody.jl",
+    )
+end

--- a/docs/src/Rayleigh-Ritz.md
+++ b/docs/src/Rayleigh-Ritz.md
@@ -179,6 +179,44 @@ save("assets/RR_SO.svg", fig) # hide
 ```
 ![](assets/RR_SO.svg)
 
+## STO-3G
+
+This example reproduces the STO-3G calculation for hydrogen reported by [Pérez-Torres (2019)](https://doi.org/10.1021/acs.jchemed.8b00959). In the contracted calculation, the published coefficients are held fixed, and the resulting contracted function is supplied to the solver. In the uncontracted calculation, the three primitive functions are supplied separately, allowing the Rayleigh–Ritz solver to optimize their linear coefficients.
+
+```@example perez_sto3g
+using TwoBody
+
+# Hamiltonian
+H = Hamiltonian(
+  Kinetic(hbar=1.0, m=1.0),
+  Coulomb(coefficient=-1.0),
+)
+
+# parameters
+α = (0.109818, 0.405771, 2.227660)
+C = (0.444635, 0.535328, 0.154329)
+
+# basis set
+primitives = ntuple(i -> SimpleGaussianBasis(α[i]), 3)
+normalization = ntuple(i -> (2α[i] / π)^(3/4), 3)
+coefficients = ntuple(i -> C[i] * normalization[i], 3)
+contracted_basis = ContractedBasis(coefficients, primitives)
+
+# solve
+contracted = solve(H, BasisSet(contracted_basis))
+uncontracted = solve(H, BasisSet(primitives...))
+
+# results
+println("Contracted STO-3G")
+println("  This work: ", contracted.E[1])
+println("  Reference: ", -0.494908)
+println("Uncontracted STO-3G")
+println("  This work: ", uncontracted.E[1])
+println("  Reference: ", -0.495010)
+```
+
+The results agree with those in Table 1 of the Supporting Information. The small differences between the calculated and reference values arise from rounding in the published parameters.
+
 ## API reference
 
 ### Solver

--- a/src/Basis.jl
+++ b/src/Basis.jl
@@ -7,9 +7,21 @@ abstract type PrimitiveBasis <: Basis end
 
 # struct
 
-struct BasisSet
-  basis::Vector{Basis}
-  BasisSet(args...) = new([args...])
+struct BasisSet{B<:Basis}
+  basis::Vector{B}
+
+  BasisSet(basis::Vector{B}, ::Val{:validated}) where {B<:Basis} = new{B}(basis)
+end
+
+function BasisSet(args::Basis...)
+  isempty(args) && return BasisSet(Basis[], Val(:validated))
+
+  basis_type = foldl(typejoin, (typeof(basis) for basis in args))
+  stored_basis = Vector{basis_type}(undef, length(args))
+  for index in eachindex(args)
+    stored_basis[index] = args[index]
+  end
+  return BasisSet(stored_basis, Val(:validated))
 end
 
 function geometric(r₁, rₙ, n::Int; nₘₐₓ::Int=n, nₘᵢₙ::Int=1)
@@ -34,20 +46,54 @@ Base.@kwdef struct GeometricBasisSet
   end
 end
 
-Base.@kwdef struct SimpleGaussianBasis <: PrimitiveBasis
-  a = 1
+Base.@kwdef struct SimpleGaussianBasis{T<:Real} <: PrimitiveBasis
+  a::T = 1
 end
 
-Base.@kwdef struct GaussianBasis <: PrimitiveBasis
-  a = 1
-  l = 0
-  m = 0
+Base.@kwdef struct GaussianBasis{T<:Real} <: PrimitiveBasis
+  a::T = 1
+  l::Int = 0
+  m::Int = 0
 end
 
-struct ContractedBasis <: Basis
-  c::Vector
-  φ::Vector
+struct ContractedBasis{N, T<:Number, P<:NTuple{N,PrimitiveBasis}} <: Basis
+  coefficients::NTuple{N,T}
+  primitives::P
+
+  function ContractedBasis(
+    coefficients::NTuple{N,T},
+    primitives::P,
+    ::Val{:validated},
+  ) where {N, T<:Number, P<:NTuple{N,PrimitiveBasis}}
+    N > 0 || throw(ArgumentError("a contracted basis requires at least one coefficient and primitive basis"))
+    new{N,T,P}(coefficients, primitives)
+  end
 end
+
+function ContractedBasis(
+  coefficients::C,
+  primitives::P,
+) where {N, C<:NTuple{N,Number}, P<:NTuple{N,PrimitiveBasis}}
+  N > 0 || throw(ArgumentError("a contracted basis requires at least one coefficient and primitive basis"))
+  return ContractedBasis(promote(coefficients...), primitives, Val(:validated))
+end
+
+function _contracted_basis(coefficients, primitives)
+  isempty(coefficients) && throw(ArgumentError("a contracted basis requires at least one coefficient and primitive basis"))
+  length(coefficients) == length(primitives) || throw(DimensionMismatch("the numbers of coefficients and primitive bases must match"))
+  all(coefficient -> coefficient isa Number, coefficients) || throw(ArgumentError("all contraction coefficients must be numbers"))
+  all(primitive -> primitive isa PrimitiveBasis, primitives) || throw(ArgumentError("all components of a contracted basis must be primitive bases"))
+
+  coefficient_values = Tuple(coefficients)
+  stored_primitives = Tuple(primitives)
+  coefficient_type = foldl(promote_type, (typeof(coefficient) for coefficient in coefficient_values))
+  stored_coefficients = ntuple(index -> convert(coefficient_type, coefficient_values[index]), length(coefficient_values))
+
+  return ContractedBasis(stored_coefficients, stored_primitives, Val(:validated))
+end
+
+ContractedBasis(coefficients::AbstractVector, primitives::AbstractVector) = ContractedBasis(Tuple(coefficients), Tuple(primitives))
+ContractedBasis(coefficients::Tuple, primitives::Tuple) = _contracted_basis(coefficients, primitives)
 
 # utility
 
@@ -55,16 +101,38 @@ Base.string(b::Basis) = "$(typeof(b))(" * join(["$(symbol)=$(getproperty(b,symbo
 Base.string(bs::BasisSet) = "BasisSet(" * join(["$(b)" for b in bs.basis], ", ") * ")"
 Base.show(io::IO, b::Basis) = print(io, Base.string(b))
 Base.show(io::IO, bs::BasisSet) = print(io, Base.string(bs))
+@inline function Base.getproperty(b::ContractedBasis, name::Symbol)
+  name === :c && return getfield(b, :coefficients)
+  name === :φ && return getfield(b, :primitives)
+  return getfield(b, name)
+end
+Base.propertynames(::ContractedBasis, ::Bool=false) = (:coefficients, :primitives, :c, :φ)
 Base.getindex(BS::BasisSet, index) = BS.basis[index]
 Base.getindex(GBS::GeometricBasisSet, index) = GBS.basis[index]
 Base.length(BS::BasisSet) = length(BS.basis)
 Base.length(GBS::GeometricBasisSet) = length(GBS.basis)
+Base.length(::ContractedBasis{N}) where {N} = N
 
 # function
 
 φ(b::SimpleGaussianBasis, r) = exp(-b.a*r^2)
 φ(b::GaussianBasis, r, θ, φ) = N(b.l) * r^b.l * exp(-b.a*r^2) * Y(b.l, b.m, θ, φ)
-φ(b::ContractedBasis, r, θ, φ) = sum(b.c[i] * φ(b.φ[i], r, θ, φ) for i in 1:length(b.c))
+@inline φ(b::ContractedBasis, coordinates...) = _contracted_value(
+  getfield(b, :coefficients),
+  getfield(b, :primitives),
+  coordinates,
+)
+@inline _contracted_value(coefficients::Tuple{T}, primitives::Tuple{P}, coordinates) where {T,P} =
+  first(coefficients) * φ(first(primitives), coordinates...)
+@inline _contracted_value(coefficients::Tuple, primitives::Tuple, coordinates) = muladd(
+  first(coefficients),
+  φ(first(primitives), coordinates...),
+  _contracted_value(Base.tail(coefficients), Base.tail(primitives), coordinates),
+)
+
+_replace_exponent(b::SimpleGaussianBasis, a) = SimpleGaussianBasis(a)
+_replace_exponent(b::GaussianBasis, a) = GaussianBasis(a=a, l=b.l, m=b.m)
+_replace_exponent(b::Basis, a) = typeof(b)(a)
 
 # function for testing
 
@@ -94,6 +162,10 @@ end
 \{ \phi_1, \phi_2, \phi_3, \cdots  \}
 ```
 The basis set is the input for Rayleigh-Ritz method. You can define the basis set like this:
+
+The concrete element type is preserved when all basis functions have a common
+type, avoiding abstract `Basis` dispatch in matrix-construction loops.
+
 ```math
 \begin{aligned}
   \phi_1(r) &= \exp(-13.00773 ~r^2), \\
@@ -324,8 +396,22 @@ k^l e^{-\frac{k^2}{4\alpha}}
 """ GaussianBasis
 
 @doc raw"""
-`ContractedBasis([c1, c2, ...], [basis1, basis2, ...])`
+`ContractedBasis([c1, c2, ...], [primitive1, primitive2, ...])`
 ```math
 \phi' = \sum_i c_i \phi_i
 ```
+
+A contracted basis is a nonempty linear combination of `PrimitiveBasis`
+objects. The numbers of coefficients and primitive bases must match. Numeric
+coefficient types are promoted to a common type.
+
+The components are stored in tuples, making their number part of the type and
+preserving the concrete type of every primitive basis. This lets Julia
+specialize and inline evaluation without dispatching through an abstract
+`PrimitiveBasis` container. Tuple inputs are recommended when constructing a
+basis in performance-sensitive code; vectors are also accepted and converted
+once during construction.
+
+The fields are named `coefficients` and `primitives`. The aliases `c` and `φ`
+are retained for compatibility.
 """ ContractedBasis

--- a/src/Rayleigh-Ritz.jl
+++ b/src/Rayleigh-Ritz.jl
@@ -230,7 +230,7 @@ function optimize(hamiltonian::Hamiltonian, basisset::BasisSet; perturbation=Ham
     x -> try
       E = solve(
         hamiltonian,
-        BasisSet([typeof(basisset.basis[i])(x[i]) for i in keys(basisset.basis)]...),
+        BasisSet([_replace_exponent(basisset.basis[i], x[i]) for i in keys(basisset.basis)]...),
         perturbation = perturbation,
         info = -1
       ).E[1]
@@ -250,7 +250,7 @@ function optimize(hamiltonian::Hamiltonian, basisset::BasisSet; perturbation=Ham
   )
 
   # result
-  res = solve(hamiltonian, BasisSet([typeof(basisset.basis[i])(res.minimizer[i]) for i in keys(basisset.basis)]...), perturbation=perturbation, info=info)
+  res = solve(hamiltonian, BasisSet([_replace_exponent(basisset.basis[i], res.minimizer[i]) for i in keys(basisset.basis)]...), perturbation=perturbation, info=info)
   if 0 ≤ info
     return ResultRayleighRitz(;
       optimizer = optimizer,
@@ -411,6 +411,72 @@ end
 function element(o::Gaussian, SGB1::SimpleGaussianBasis, SGB2::SimpleGaussianBasis)
   return o.coefficient * (π/(o.exponent+SGB1.a+SGB2.a))^(3/2)
 end
+
+@inline function element(B1::ContractedBasis, B2::Basis)
+  return _contracted_bra_element(
+    getfield(B1, :coefficients),
+    getfield(B1, :primitives),
+    B2,
+  )
+end
+
+@inline function element(B1::PrimitiveBasis, B2::ContractedBasis)
+  return _contracted_ket_element(
+    B1,
+    getfield(B2, :coefficients),
+    getfield(B2, :primitives),
+  )
+end
+
+@inline function element(o::Operator, B1::ContractedBasis, B2::Basis)
+  return _contracted_bra_element(
+    o,
+    getfield(B1, :coefficients),
+    getfield(B1, :primitives),
+    B2,
+  )
+end
+
+@inline function element(o::Operator, B1::PrimitiveBasis, B2::ContractedBasis)
+  return _contracted_ket_element(
+    o,
+    B1,
+    getfield(B2, :coefficients),
+    getfield(B2, :primitives),
+  )
+end
+
+@inline _contracted_bra_element(coefficients::Tuple{T}, primitives::Tuple{P}, B2::Basis) where {T,P} =
+  conj(first(coefficients)) * element(first(primitives), B2)
+@inline _contracted_bra_element(coefficients::Tuple, primitives::Tuple, B2::Basis) = muladd(
+  conj(first(coefficients)),
+  element(first(primitives), B2),
+  _contracted_bra_element(Base.tail(coefficients), Base.tail(primitives), B2),
+)
+
+@inline _contracted_ket_element(B1::PrimitiveBasis, coefficients::Tuple{T}, primitives::Tuple{P}) where {T,P} =
+  first(coefficients) * element(B1, first(primitives))
+@inline _contracted_ket_element(B1::PrimitiveBasis, coefficients::Tuple, primitives::Tuple) = muladd(
+  first(coefficients),
+  element(B1, first(primitives)),
+  _contracted_ket_element(B1, Base.tail(coefficients), Base.tail(primitives)),
+)
+
+@inline _contracted_bra_element(o::Operator, coefficients::Tuple{T}, primitives::Tuple{P}, B2::Basis) where {T,P} =
+  conj(first(coefficients)) * element(o, first(primitives), B2)
+@inline _contracted_bra_element(o::Operator, coefficients::Tuple, primitives::Tuple, B2::Basis) = muladd(
+  conj(first(coefficients)),
+  element(o, first(primitives), B2),
+  _contracted_bra_element(o, Base.tail(coefficients), Base.tail(primitives), B2),
+)
+
+@inline _contracted_ket_element(o::Operator, B1::PrimitiveBasis, coefficients::Tuple{T}, primitives::Tuple{P}) where {T,P} =
+  first(coefficients) * element(o, B1, first(primitives))
+@inline _contracted_ket_element(o::Operator, B1::PrimitiveBasis, coefficients::Tuple, primitives::Tuple) = muladd(
+  first(coefficients),
+  element(o, B1, first(primitives)),
+  _contracted_ket_element(o, B1, Base.tail(coefficients), Base.tail(primitives)),
+)
 
 function element(o::Hamiltonian, B1::Basis, B2::Basis)
   return sum(element(term, B1, B2) for term in o.terms)

--- a/test/Basis.jl
+++ b/test/Basis.jl
@@ -6,6 +6,8 @@
     SimpleGaussianBasis(0.444529),
     SimpleGaussianBasis(0.1219492),
   )
+  @test eltype(BS.basis) === SimpleGaussianBasis{Float64}
+  @test isconcretetype(eltype(BS.basis))
 
   println("φ(SGB,r) = exp(-a*r^2)")
   println("    a\t    r\tnumerical  \tanalytical")
@@ -20,6 +22,47 @@
         @test acceptance
       end
     end
+
+    typed = SimpleGaussianBasis(1.0)
+    @test typed isa SimpleGaussianBasis{Float64}
+    @test fieldtype(typeof(typed), :a) === Float64
+    @test (@inferred TwoBody.φ(typed, 0.3)) isa Float64
+  end
+
+  @testset "ContractedBasis" begin
+    primitives = PrimitiveBasis[SimpleGaussianBasis(1.0), SimpleGaussianBasis(2.0)]
+    contracted = ContractedBasis(Number[1, 0.5], primitives)
+
+    @test contracted isa ContractedBasis{2,Float64,Tuple{SimpleGaussianBasis{Float64},SimpleGaussianBasis{Float64}}}
+    @test contracted.coefficients == (1.0, 0.5)
+    @test contracted.primitives == Tuple(primitives)
+    @test contracted.c === contracted.coefficients
+    @test contracted.φ === contracted.primitives
+    @test length(contracted) == 2
+    @test TwoBody.φ(contracted, 0.3) ≈ sum(
+      contracted.coefficients[i] * TwoBody.φ(contracted.primitives[i], 0.3)
+      for i in eachindex(contracted.coefficients)
+    )
+
+    coefficients = [1.0, 0.5]
+    copied = ContractedBasis(coefficients, primitives)
+    coefficients[1] = 2.0
+    primitives[1] = SimpleGaussianBasis(3.0)
+    @test copied.coefficients == (1.0, 0.5)
+    @test copied.primitives == (SimpleGaussianBasis(1.0), SimpleGaussianBasis(2.0))
+
+    from_tuples = @inferred ContractedBasis((1, 0.5), (SimpleGaussianBasis(1.0), SimpleGaussianBasis(2.0)))
+    @test typeof(from_tuples) === typeof(contracted)
+    @test isbitstype(typeof(from_tuples))
+    @test (@inferred TwoBody.φ(from_tuples, 0.3)) ≈ TwoBody.φ(contracted, 0.3)
+
+    heterogeneous = ContractedBasis((1, 1), (SimpleGaussianBasis(), GaussianBasis()))
+    @test heterogeneous isa ContractedBasis{2,Int,Tuple{SimpleGaussianBasis{Int},GaussianBasis{Int}}}
+
+    @test_throws ArgumentError ContractedBasis(Float64[], SimpleGaussianBasis[])
+    @test_throws DimensionMismatch ContractedBasis([1.0], [SimpleGaussianBasis(1.0), SimpleGaussianBasis(2.0)])
+    @test_throws ArgumentError ContractedBasis(Any[1.0, "invalid"], PrimitiveBasis[SimpleGaussianBasis(1.0), SimpleGaussianBasis(2.0)])
+    @test_throws ArgumentError ContractedBasis([1.0], Any["invalid"])
   end
 
   println("φ(r) = exp(-ar²)")

--- a/test/Rayleigh-Ritz.jl
+++ b/test/Rayleigh-Ritz.jl
@@ -57,6 +57,103 @@
   @printf("%3d\t%.9f\t%.9f\t%s\n", 1, numerical, analytical, acceptance ? "✔" :  "✗")
   @test acceptance
 
+  @testset "Pérez-Torres STO-3G contraction" begin
+    exponents = (0.109818, 0.405771, 2.227660)
+    contraction = (0.444635, 0.535328, 0.154329)
+    primitives = ntuple(i -> SimpleGaussianBasis(exponents[i]), 3)
+    normalization = ntuple(i -> (2exponents[i] / π)^(3/4), 3)
+    coefficients = ntuple(i -> contraction[i] * normalization[i], 3)
+    sto3g = ContractedBasis(coefficients, primitives)
+
+    primitive_set = BasisSet(primitives...)
+    coefficient_vector = collect(coefficients)
+    primitive_overlap = TwoBody.matrix(primitive_set)
+
+    @test TwoBody.element(sto3g, sto3g) ≈ coefficient_vector' * primitive_overlap * coefficient_vector
+    @test TwoBody.element(sto3g, primitives[1]) ≈ sum(
+      conj(coefficients[i]) * TwoBody.element(primitives[i], primitives[1])
+      for i in eachindex(coefficients)
+    )
+    @test TwoBody.element(primitives[1], sto3g) ≈ sum(
+      coefficients[i] * TwoBody.element(primitives[1], primitives[i])
+      for i in eachindex(coefficients)
+    )
+
+    for operator in H.terms
+      primitive_matrix = TwoBody.matrix(operator, primitive_set)
+      @test TwoBody.element(operator, sto3g, sto3g) ≈ coefficient_vector' * primitive_matrix * coefficient_vector
+      @test TwoBody.element(operator, sto3g, primitives[1]) ≈ sum(
+        conj(coefficients[i]) * TwoBody.element(operator, primitives[i], primitives[1])
+        for i in eachindex(coefficients)
+      )
+      @test TwoBody.element(operator, primitives[1], sto3g) ≈ sum(
+        coefficients[i] * TwoBody.element(operator, primitives[1], primitives[i])
+        for i in eachindex(coefficients)
+      )
+    end
+
+    primitive_hamiltonian = TwoBody.matrix(H, primitive_set)
+    @test TwoBody.element(H, sto3g, sto3g) ≈ coefficient_vector' * primitive_hamiltonian * coefficient_vector
+
+    radius = Linear(coefficient=1)
+    radius_squared = PowerLaw(coefficient=1, exponent=2)
+    inverse_radius = Coulomb(coefficient=1)
+    properties = Hamiltonian(radius, radius_squared, inverse_radius)
+
+    contracted_result = solve(H, BasisSet(sto3g), perturbation=properties)
+    uncontracted_result = solve(H, primitive_set, perturbation=properties)
+
+    @test contracted_result.E[1] ≈ -0.494907096570 atol=1e-11
+    @test uncontracted_result.E[1] ≈ -0.495010402012 atol=1e-11
+    @test contracted_result.E[1] ≈ -0.494908 atol=2e-6
+    @test uncontracted_result.E[1] ≈ -0.495010 atol=1e-6
+    @test uncontracted_result.E[1] < contracted_result.E[1]
+
+    @test contracted_result.expectation[radius][1] ≈ 1.500392 atol=2e-6
+    @test contracted_result.expectation[radius_squared][1] ≈ 2.996124 atol=5e-6
+    @test contracted_result.expectation[inverse_radius][1] ≈ 0.989206 atol=2e-6
+    @test 2 * contracted_result.expectation[H.terms[1]][1] ≈ 0.988596 atol=2e-6
+
+    @test uncontracted_result.expectation[radius][1] ≈ 1.514699 atol=1e-6
+    @test uncontracted_result.expectation[radius_squared][1] ≈ 3.046195 atol=1e-6
+    @test uncontracted_result.expectation[inverse_radius][1] ≈ 0.977070 atol=1e-6
+    @test 2 * uncontracted_result.expectation[H.terms[1]][1] ≈ 0.964119 atol=1e-6
+
+    @test contracted_result.S[1,1] ≈ 1.0 atol=2e-6
+    @test 4π * quadgk(r -> r^2 * abs2(TwoBody.ψ(contracted_result, r)), 0, Inf)[1] ≈ 1.0 atol=1e-9
+    @test 4π * quadgk(r -> r^2 * abs2(TwoBody.ψ(uncontracted_result, r)), 0, Inf)[1] ≈ 1.0 atol=1e-9
+
+    # Independent radial quadrature does not use element() or matrix().
+    numerical_components = function (orbital)
+      orbital_derivative = r -> ForwardDiff.derivative(orbital, r)
+      overlap = 4π * quadgk(r -> r^2 * abs2(orbital(r)), 0, Inf, rtol=1e-12)[1]
+      kinetic = 2π * quadgk(r -> r^2 * abs2(orbital_derivative(r)), 0, Inf, rtol=1e-12)[1]
+      coulomb = -4π * quadgk(r -> r * abs2(orbital(r)), 0, Inf, rtol=1e-12)[1]
+      return (overlap=overlap, kinetic=kinetic, coulomb=coulomb, energy=(kinetic+coulomb)/overlap)
+    end
+
+    contracted_numerical = numerical_components(r -> TwoBody.φ(sto3g, r))
+    uncontracted_numerical = numerical_components(r -> TwoBody.ψ(uncontracted_result, r))
+
+    @test contracted_numerical.overlap ≈ TwoBody.element(sto3g, sto3g) atol=1e-10
+    @test contracted_numerical.kinetic ≈ TwoBody.element(H.terms[1], sto3g, sto3g) atol=1e-10
+    @test contracted_numerical.coulomb ≈ TwoBody.element(H.terms[2], sto3g, sto3g) atol=1e-10
+    @test contracted_numerical.energy ≈ contracted_result.E[1] atol=1e-10
+    @test uncontracted_numerical.overlap ≈ 1.0 atol=1e-10
+    @test uncontracted_numerical.energy ≈ uncontracted_result.E[1] atol=1e-10
+
+    complex_coefficients = (1 + 0.5im, -0.25im)
+    complex_basis = ContractedBasis(complex_coefficients, (primitives[1], primitives[2]))
+    @test TwoBody.element(complex_basis, primitives[1]) ≈ sum(
+      conj(complex_coefficients[i]) * TwoBody.element(primitives[i], primitives[1])
+      for i in eachindex(complex_coefficients)
+    )
+    @test TwoBody.element(primitives[1], complex_basis) ≈ sum(
+      complex_coefficients[i] * TwoBody.element(primitives[1], primitives[i])
+      for i in eachindex(complex_coefficients)
+    )
+  end
+
   # comparison with Antique.jl
   HA = Antique.HydrogenAtom(Z=1, m_e=1.0, a_0=1.0, E_h=1.0, hbar=1.0)
 


### PR DESCRIPTION
## Summary

- Add a type-stable `ContractedBasis` backed by tuples and preserve concrete basis types in `BasisSet`.
- Assemble overlap and operator matrix elements for contracted basis functions, including complex bra coefficients.
- Add tests for construction, matrix elements, variational calculations, and independent radial quadrature.
- Document contracted and uncontracted STO-3G calculations using the Pérez-Torres hydrogen example.
- Allow documentation to build locally without attempting deployment.

## Why

This adds fixed Gaussian contractions while retaining efficient dispatch and lets contracted functions participate directly in Rayleigh–Ritz calculations. The STO-3G example also demonstrates the distinction between fixed contraction coefficients and independently optimized primitive coefficients.

## Validation

- Full test suite: 363/363 tests passed.
- Documenter build completed successfully, including the executable STO-3G example.

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.