### PR TITLE
Add GEM to hydrogen benchmark

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -92,7 +92,8 @@ The following table compares the two lowest ``s``-wave energies of the
 hydrogen atom in atomic units. Here ``n=0`` denotes the ground state and
 ``n=1`` the first excited state. The numerical values use the example settings
 from the corresponding method pages: 20 Gaussian functions for RR, the
-nine-function complement basis (``M_n=9``) for FC, ``\Delta r=0.1`` and
+nine-function complement basis (``M_n=9``) for FC, 20 real-range Gaussians
+with ``r_1=0.1`` and ``r_{20}=80`` for GEM, ``\Delta r=0.1`` and
 ``r_\mathrm{max}=50`` for FDM, the default 1024-point grid
 (``\mathtt{quantics}=10``) for QTT+DMRG, and the documented training or
 sampling settings for VNN and VMC. A dash indicates that the state is not
@@ -102,6 +103,7 @@ currently available.
 |:---|---:|---:|
 | [RR](@ref Rayleigh-Ritz-Method) | -0.499981735104 | -0.124997703473 |
 | [FC](@ref Free-Complement-Method) | -0.499999999978 | -0.123665583532 |
+| [GEM](@ref Gaussian-Expansion-Method) | -0.499981735103 | -0.124997703473 |
 | [FDM](@ref Finite-Difference-Method) | -0.498756211209 | -0.124921972504 |
 | [QTT+DMRG](@ref Quantics-Tensor-Train) | -0.499702911360 | -0.124981415403 |
 | [VNN](@ref Variational-Neural-Network) | -0.468779111883 | — |


### PR DESCRIPTION
## Summary

- add GEM to the hydrogen benchmark table
- document the real-range Gaussian settings used for the reported values

## Validation

- reproduced the two GEM energies with the documented 20-function basis
- `git diff --check`

Closes #48

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.
