### PR TITLE
Add Weinstein energy bounds

### DIFF
--- a/docs/src/Rayleigh-Ritz.md
+++ b/docs/src/Rayleigh-Ritz.md
@@ -146,6 +146,25 @@ which is amazingly good for only four basis functions according to [Thijssen(200
 solve(H, BS)
 ```
 
+## Weinstein bound
+
+For a normalized approximate eigenstate, the Weinstein interval is
+
+```math
+E-\sigma \le E_\mathrm{exact} \le E+\sigma,
+\qquad
+\sigma^2=\langle H^2\rangle-E^2.
+```
+
+`weinstein` evaluates ``\langle H^2\rangle`` by applying the non-relativistic radial Hamiltonian to the Rayleigh–Ritz wavefunction. The Hamiltonian may contain `Laplacian`, `Kinetic`, `RestEnergy`, and potential terms defined by `V`.
+
+```@example example
+bound = weinstein(solve(H, BS))
+(bound.lower, bound.upper)
+```
+
+Reference: D. H. Weinstein, [*Proc. Natl. Acad. Sci. U.S.A.* **20**, 529–532 (1934)](https://doi.org/10.1073/pnas.20.9.529).
+
 ## Example of Hydrogen Atom
 
 Analytical solutions are implemented in [Antique.jl](https://ohno.github.io/Antique.jl/stable/HydrogenAtom/).
@@ -303,6 +322,7 @@ solve(hamiltonian::Hamiltonian, basisset::GeometricBasisSet; perturbation=Hamilt
 optimize(hamiltonian::Hamiltonian, basisset::BasisSet; perturbation=Hamiltonian(), info=4, progress=true, optimizer=Optim.NelderMead(), options...)
 optimize(hamiltonian::Hamiltonian, basis::Basis; perturbation=Hamiltonian(), info=1, progress=true, optimizer=Optim.NelderMead(), options...)
 optimize(hamiltonian::Hamiltonian, basisset::GeometricBasisSet; perturbation=Hamiltonian(), info=4, progress=true, optimizer=Optim.NelderMead(), options...)
+weinstein
 ```
 
 ### Basis Set

--- a/src/Rayleigh-Ritz.jl
+++ b/src/Rayleigh-Ritz.jl
@@ -1,9 +1,10 @@
-export solve, optimize
+export solve, optimize, WeinsteinBound, weinstein
 
 import LinearAlgebra
 import Optim
 import Printf
 import QuadGK
+import ForwardDiff
 import SpecialFunctions
 import Subscripts
 
@@ -14,8 +15,70 @@ struct ResultRayleighRitz
   ResultRayleighRitz(; args...) = new(NamedTuple(Dict(args)))
 end
 
+struct WeinsteinBound{T<:Real}
+  E::T
+  variance::T
+  lower::T
+  upper::T
+end
+
 function ψ(result::ResultRayleighRitz, r; n::Int=1)
   return sum(result.C[i,n] * TwoBody.φ(result.basisset[i], r) for i in 1:result.nₘₐₓ)
+end
+
+Base.show(io::IO, bound::WeinsteinBound) = print(
+  io,
+  "WeinsteinBound(E=$(bound.E), lower=$(bound.lower), upper=$(bound.upper))",
+)
+
+_weinstein_laplacian(wavefunction, r, l) =
+  ForwardDiff.derivative(x -> ForwardDiff.derivative(wavefunction, x), r) +
+  2 / r * ForwardDiff.derivative(wavefunction, r) -
+  l * (l + 1) / r^2 * wavefunction(r)
+
+_weinstein_action(o::Laplacian, wavefunction, r, l) =
+  o.coefficient * _weinstein_laplacian(wavefunction, r, l)
+
+_weinstein_action(o::Kinetic, wavefunction, r, l) =
+  -o.hbar^2 / (2o.m) * _weinstein_laplacian(wavefunction, r, l)
+
+_weinstein_action(o::RestEnergy, wavefunction, r, l) = o.m * o.c^2 * wavefunction(r)
+_weinstein_action(o::PotentialTerm, wavefunction, r, l) = V(o, r) * wavefunction(r)
+_weinstein_action(o::Operator, wavefunction, r, l) =
+  throw(ArgumentError("Weinstein bound does not support $(typeof(o))"))
+
+function _weinstein_angular_momentum(basisset::BasisSet)
+  angular_momenta = unique(hasproperty(basis, :l) ? basis.l : 0 for basis in basisset.basis)
+  length(angular_momenta) == 1 ||
+    throw(ArgumentError("all basis functions must have the same angular momentum"))
+  return only(angular_momenta)
+end
+
+function weinstein(result::ResultRayleighRitz; n::Int=1)
+  haskey(result, :hamiltonian) || throw(ArgumentError("the full solver result is required"))
+  1 <= n <= result.nₘₐₓ || throw(BoundsError(result.E, n))
+
+  l = _weinstein_angular_momentum(result.basisset)
+  wavefunction = r -> ψ(result, r; n=n)
+  hamiltonian_wavefunction = r -> sum(
+    _weinstein_action(term, wavefunction, r, l)
+    for term in result.hamiltonian.terms
+  )
+  second_moment, _ = QuadGK.quadgk(
+    r -> 4π * r^2 * abs2(hamiltonian_wavefunction(r)),
+    0.0,
+    Inf,
+    rtol=1e-9,
+    atol=1e-11,
+  )
+
+  E = real(result.E[n])
+  variance = real(second_moment) - E^2
+  tolerance = 100eps(float(E)) * max(abs(second_moment), E^2, one(E))
+  variance >= -tolerance || throw(ErrorException("calculated energy variance is negative"))
+  variance = max(variance, zero(variance))
+  deviation = sqrt(variance)
+  return WeinsteinBound(E, variance, E - deviation, E + deviation)
 end
 
 Base.getproperty(result::ResultRayleighRitz, symbol::Symbol) = Base.getproperty(getfield(result,:data), symbol)
@@ -511,6 +574,12 @@ function element(o::Hamiltonian, B1::Basis, B2::Basis)
 end
 
 # docstring
+
+@doc raw"""
+`weinstein(result::ResultRayleighRitz; n=1)`
+
+Return the Weinstein energy interval for state `n`.
+""" weinstein
 
 @doc raw"""
 `solve(hamiltonian::Hamiltonian, basisset::BasisSet)`

--- a/test/Rayleigh-Ritz.jl
+++ b/test/Rayleigh-Ritz.jl
@@ -57,6 +57,16 @@
   @printf("%3d\t%.9f\t%.9f\t%s\n", 1, numerical, analytical, acceptance ? "✔" :  "✗")
   @test acceptance
 
+  @testset "Weinstein bound" begin
+    bound = weinstein(res)
+    @test bound.E == res.E[1]
+    @test bound.lower < -0.5 < bound.upper
+    @test bound.variance >= 0
+    @test sprint(show, bound) == "WeinsteinBound(E=$(bound.E), lower=$(bound.lower), upper=$(bound.upper))"
+    @test_throws BoundsError weinstein(res; n=0)
+    @test_throws ArgumentError weinstein(solve(H, BS; info=0))
+  end
+
   @testset "Pérez-Torres STO-3G contraction" begin
     exponents = (0.109818, 0.405771, 2.227660)
     contraction = (0.444635, 0.535328, 0.154329)


### PR DESCRIPTION
## Summary

- add `weinstein` and `WeinsteinBound` for Rayleigh–Ritz results
- evaluate the energy variance from the continuous radial Hamiltonian action
- support non-relativistic kinetic, Laplacian, rest-energy, and radial potential terms
- document the bound, usage, and original reference

## Impact

Users can calculate `E ± σ` without obtaining the artificial zero variance produced by projecting `H²` back into the finite variational basis.

## Validation

- `Pkg.test()` — 557/557 tests passed
- complete Documenter build passed
- no method ambiguities detected
- the documented hydrogen interval contains the exact energy
- `git diff --check`

Closes #50

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.
