### PR TITLE
Add complex scaling method

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ pages = gem_only ?
         "Database" => "DB.md",
         "Rayleigh-Ritz Method" => "Rayleigh-Ritz.md",
         "Gaussian Expansion Method" => "GEM.md",
+        "Complex Scaling Method" => "CSM.md",
         "Free Complement Method" => "Free-Complement.md",
         "Finite Difference Method" => "FDM.md",
         "Quantics Tensor Train" => "QTT.md",

--- a/docs/src/CSM.md
+++ b/docs/src/CSM.md
@@ -1,0 +1,39 @@
+```@meta
+CurrentModule = TwoBody
+```
+
+# Complex Scaling Method
+
+Complex scaling rotates the radial coordinate by a real angle ``θ``:
+
+```math
+r \rightarrow r e^{iθ}, \qquad
+H^θ = e^{-2iθ}T + V(r e^{iθ}).
+```
+
+The bound-state spectrum is unchanged, while the continuum rotates by ``2θ``.
+Resonance poles can therefore be separated from the continuum. See Myo and Kato,
+[Prog. Theor. Exp. Phys. 2020, 12A101](https://doi.org/10.1093/ptep/ptaa101).
+
+## Usage
+
+```@example csm
+using TwoBody
+
+H = Hamiltonian(Kinetic(hbar=1, m=1), Coulomb(coefficient=-1))
+basisset = GeometricBasisSet(GaussianBasis, 0.1, 20.0, 12)
+method = ComplexScalingMethod(basisset; θ=0.2)
+result = solve(H, method)
+result.E[1]
+```
+
+`Tabulated` potentials are not supported because their analytic continuation is
+undefined.
+
+## API reference
+
+```@docs; canonical=false
+ComplexScalingMethod
+ResultComplexScaling
+solve(hamiltonian::Hamiltonian, method::ComplexScalingMethod)
+```

--- a/src/CSM.jl
+++ b/src/CSM.jl
@@ -1,0 +1,119 @@
+export ComplexScalingMethod, ResultComplexScaling
+
+import LinearAlgebra
+import Subscripts
+
+struct ComplexScalingMethod{B<:Union{BasisSet,GeometricBasisSet},T<:Real}
+  basisset::B
+  θ::T
+  function ComplexScalingMethod(basisset::B; θ::T=zero(Float64)) where {B<:Union{BasisSet,GeometricBasisSet},T<:Real}
+    0 ≤ θ < π / 2 || throw(ArgumentError("θ must satisfy 0 ≤ θ < π/2"))
+    new{B,T}(basisset, θ)
+  end
+end
+
+ComplexScalingMethod(basis::Basis; θ=zero(Float64)) =
+  ComplexScalingMethod(BasisSet(basis); θ=θ)
+
+struct ResultComplexScaling
+  data::Any
+  ResultComplexScaling(; args...) = new(NamedTuple(Dict(args)))
+end
+
+Base.getproperty(result::ResultComplexScaling, symbol::Symbol) =
+  Base.getproperty(getfield(result, :data), symbol)
+Base.show(io::IO, method::ComplexScalingMethod) = print(io, Base.string(method))
+Base.show(io::IO, result::ResultComplexScaling) = print(io, Base.string(result))
+
+Base.string(method::ComplexScalingMethod) =
+  "ComplexScalingMethod(θ=$(method.θ), basisset=$(method.basisset))"
+
+function Base.string(result::ResultComplexScaling)
+  text = "# method\n\n$(result.method)\n\n# eigenvalue\n\n"
+  for n in eachindex(result.E)
+    text *= "E$(Subscripts.sub(string(n))) = $(result.E[n])\n"
+  end
+  return text
+end
+
+function ψ(result::ResultComplexScaling, r; n::Int=1)
+  return sum(result.C[i,n] * φ(result.basisset[i], r) for i in 1:result.nₘₐₓ)
+end
+
+_complex_scaled(o::RestEnergy, θ) = (one(ComplexF64), o)
+_complex_scaled(o::Laplacian, θ) = (cis(-2θ), o)
+_complex_scaled(o::Kinetic, θ) = (cis(-2θ), o)
+_complex_scaled(o::RelativisticCorrection, θ) = (cis(-2o.n * θ), o)
+_complex_scaled(o::Constant, θ) = (one(ComplexF64), o)
+_complex_scaled(o::Linear, θ) = (cis(θ), o)
+_complex_scaled(o::Coulomb, θ) = (cis(-θ), o)
+_complex_scaled(o::PowerLaw, θ) = (cis(o.exponent * θ), o)
+_complex_scaled(o::Gaussian, θ) =
+  (one(ComplexF64), Gaussian(coefficient=o.coefficient, exponent=o.exponent * cis(2θ)))
+_complex_scaled(o::Exponential, θ) =
+  (one(ComplexF64), Exponential(coefficient=o.coefficient, exponent=o.exponent * cis(θ)))
+_complex_scaled(o::Yukawa, θ) =
+  (cis(-θ), Yukawa(coefficient=o.coefficient, exponent=o.exponent * cis(θ)))
+_complex_scaled(o::Delta, θ) = (cis(-3θ), o)
+_complex_scaled(o::Custom, θ) = (one(ComplexF64), Custom(f=r -> o.f(r * cis(θ))))
+
+_complex_scaled(::Tabulated, θ) =
+  throw(ArgumentError("complex scaling requires an analytic potential"))
+_complex_scaled(o::RelativisticKinetic, θ) =
+  throw(ArgumentError("complex scaling does not support $(typeof(o))"))
+
+function _complex_scaled(o::Operator, θ)
+  throw(ArgumentError("complex scaling does not support $(typeof(o))"))
+end
+
+_basis(method::ComplexScalingMethod) = method.basisset isa GeometricBasisSet ?
+  BasisSet(method.basisset.basis...) : method.basisset
+
+function matrix(operator::Operator, method::ComplexScalingMethod)
+  basisset = _basis(method)
+  factor, scaled = _complex_scaled(operator, method.θ)
+  nₘₐₓ = length(basisset)
+  M = Matrix{ComplexF64}(undef, nₘₐₓ, nₘₐₓ)
+  for j in 1:nₘₐₓ
+    for i in 1:j
+      value = factor * element(scaled, basisset[i], basisset[j])
+      M[i,j] = value
+      M[j,i] = value
+    end
+  end
+  return M
+end
+
+matrix(hamiltonian::Hamiltonian, method::ComplexScalingMethod) =
+  sum(matrix(term, method) for term in hamiltonian.terms)
+
+function solve(hamiltonian::Hamiltonian, method::ComplexScalingMethod)
+  basisset = _basis(method)
+  S = Matrix(matrix(basisset))
+  H = matrix(hamiltonian, method)
+  decomposition = LinearAlgebra.eigen(H, S)
+  order = sortperm(decomposition.values; by=real)
+  E = decomposition.values[order]
+  C = decomposition.vectors[:,order]
+  return ResultComplexScaling(;
+    hamiltonian, method, basisset, nₘₐₓ=length(basisset), H, S, E, C,
+  )
+end
+
+@doc raw"""
+`ComplexScalingMethod(basisset; θ=0.0)`
+
+Configure complex scaling by the angle ``θ``.
+""" ComplexScalingMethod
+
+@doc raw"""
+`ResultComplexScaling`
+
+Result of a complex-scaled generalized eigenvalue problem.
+""" ResultComplexScaling
+
+@doc raw"""
+`solve(hamiltonian, method::ComplexScalingMethod)`
+
+Solve the complex-scaled Hamiltonian in the configured basis.
+""" solve(hamiltonian::Hamiltonian, method::ComplexScalingMethod)

--- a/src/GEM.jl
+++ b/src/GEM.jl
@@ -202,7 +202,7 @@ function element(o::Gaussian, b1::GaussianBasis, b2::GaussianBasis)
   return o.coefficient * _normalization_product(b1, b2) * SpecialFunctions.gamma(q) / (2 * (b1.a + b2.a + o.exponent)^q)
 end
 
-function _exp_gaussian_integral(n::Integer, σ::Real, a::Real)
+function _exp_gaussian_integral(n::Integer, σ::Number, a::Real)
   n ≥ 0 || throw(ArgumentError("integral power must be nonnegative"))
   a > 0 || throw(ArgumentError("Gaussian exponent must be positive"))
   i₀ = sqrt(π) * SpecialFunctions.erfcx(σ / (2 * sqrt(a))) / (2 * sqrt(a))

--- a/src/TwoBody.jl
+++ b/src/TwoBody.jl
@@ -12,6 +12,7 @@ include("./Basis.jl")
 # Solvers
 include("./Rayleigh-Ritz.jl")
 include("./GEM.jl")
+include("./CSM.jl")
 include("./FDM.jl")
 include("./QTT.jl")
 include("./VNN.jl")

--- a/test/CSM.jl
+++ b/test/CSM.jl
@@ -1,0 +1,24 @@
+@testset "CSM.jl" begin
+  basisset = GeometricBasisSet(GaussianBasis, 0.1, 20.0, 12)
+  free = Hamiltonian(Kinetic(hbar=1, m=1))
+  θ = 0.2
+
+  unscaled = solve(free, ComplexScalingMethod(basisset))
+  scaled = solve(free, ComplexScalingMethod(basisset; θ=θ))
+  @test scaled.E ≈ cis(-2θ) .* unscaled.E rtol=1e-12
+  @test scaled.S ≈ unscaled.S
+
+  coulomb = Hamiltonian(Kinetic(hbar=1, m=1), Coulomb(coefficient=-1))
+  rayleigh_ritz = solve(coulomb, basisset, info=-1)
+  complex_scaling = solve(coulomb, ComplexScalingMethod(basisset))
+  @test complex_scaling.E ≈ rayleigh_ritz.E rtol=1e-11
+
+  gaussian = Gaussian(coefficient=-2, exponent=0.7)
+  simple = SimpleGaussianBasis(0.4)
+  method = ComplexScalingMethod(simple; θ=θ)
+  expected = -2 * (pi / (2simple.a + gaussian.exponent * cis(2θ)))^(3/2)
+  @test TwoBody.matrix(gaussian, method)[1,1] ≈ expected
+  @test TwoBody.ψ(scaled, 1.0) isa Complex
+  @test_throws ArgumentError ComplexScalingMethod(basisset; θ=-0.1)
+  @test_throws ArgumentError TwoBody.matrix(Tabulated(0.0:0.1:1.0, ones(11)), method)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using Random
   include("FC.jl")
   include("Rayleigh-Ritz.jl")
   include("GEM.jl")
+  include("CSM.jl")
   include("FDM.jl")
   include("QTT.jl")
   include("VNN.jl")


### PR DESCRIPTION
Closes #13.

## Summary

- add a complex scaling solver for Gaussian and Slater basis sets
- rotate kinetic terms and analytically continue supported potentials
- cover continuum rotation, the unscaled limit, and complex Gaussian potentials
- document the method, its result type, and the analytic-potential requirement

## Testing

- `julia --project=. --startup-file=no -e 'using Pkg; Pkg.test()'`
- `DOCUMENTER_LOCAL=true julia --project=docs --startup-file=no -e 'include("docs/make.jl")'`
- `Test.detect_ambiguities(TwoBody; recursive=true)`

---
This pull request was developed with assistance from Codex using GPT-5.6 Sol with High reasoning effort.
